### PR TITLE
Added: command line tool to test globing

### DIFF
--- a/lib_test/glob.ml
+++ b/lib_test/glob.ml
@@ -1,5 +1,5 @@
 (** This is a little command line tool to test the library.
-@author Christian Lindig <lindig@gmail.cm>
+@author Christian Lindig <lindig@gmail.com>
 *)
 
 module R = Re


### PR DESCRIPTION
I've added a small tool to test globing interactively because I wanted to understand better how globing works. It's not yet integrated into the build system but ocamlbuild has no problem building it:

```
$ ocamlbuild lib_test/glob.native
```

The binary is used like this:

```
$ ./glob.native '*.ml' lib/*
*.ml doesn't match: lib/META
*.ml matches:       lib/automata.ml
*.ml matches:       lib/automata.mli
*.ml matches:       lib/cset.ml
*.ml matches:       lib/cset.mli
*.ml doesn't match: lib/re-api.odocl
*.ml matches:       lib/re.ml
```

I think that glob matching is under documented.
