### PR TITLE
add Re.exec_iter, to iterate on all matches within a string

### DIFF
--- a/lib/re.mli
+++ b/lib/re.mli
@@ -47,6 +47,11 @@ val exec_partial :
   ?len:int ->    (* Default: -1 (until end of string) *)
   re -> string -> [ `Full | `Partial | `Mismatch ]
 
+val exec_iter :
+  ?pos:int ->    (* Default: 0 *)
+  ?len:int ->    (* Default: -1 (until end of string) *)
+  re -> string -> (substrings -> unit) -> unit
+
 (** {2 Substring extraction} *)
 
 val get : substrings -> int -> string

--- a/lib_test/test_exec_iter.ml
+++ b/lib_test/test_exec_iter.ml
@@ -1,0 +1,15 @@
+#!/usr/bin/env ocaml
+#use "topfind";;
+#require "sequence";;
+#directory "_build/lib";;
+#load "re.cma";;
+#load "re_posix.cma";;
+let re = Re_posix.re "a*(ab)" |> Re.compile;;
+let s = "aaaaabaaa aaabaaabaaaabaa axbaaba";;
+Re.exec_iter re s
+  |> Sequence.iter
+    (fun s ->
+      let i,j = Re.get_ofs s 0 in
+      Printf.printf "%s at %d,%d\n" (Re.get s 0) i j
+    );;
+


### PR DESCRIPTION
To search all occurrences of a pattern within a (large) string, this could be convenient (e.g. to search within a file).
