### PR TITLE
Re_pcre.substitute missing from mli

### DIFF
--- a/lib/re_pcre.mli
+++ b/lib/re_pcre.mli
@@ -25,6 +25,8 @@ val get_substring_ofs : substrings -> int -> int * int
 
 val pmatch : rex:regexp -> string -> bool
 
+val substitute : rex:Re.re -> subst:(string -> string) -> string -> string
+
 val full_split : ?max:int -> rex:regexp -> string -> split_result list
 
 val split : rex:regexp -> string -> string list


### PR DESCRIPTION
Accidently wasn't included when the mli was created

Noticed when compiling dose.
