### PR TITLE
Add path marks.

### DIFF
--- a/lib/re.ml
+++ b/lib/re.ml
@@ -1189,7 +1189,7 @@ let get_all {s ; marks ; gpos ; gcount } =
 let marked {pmarks} p =
   Automata.PmarkSet.mem p pmarks
 
-let get_mark_set s = s.pmarks
+let mark_set s = s.pmarks
 
 (**********************************)
 

--- a/lib/re.mli
+++ b/lib/re.mli
@@ -89,7 +89,7 @@ module MarkSet : Set.S with type elt = markid
 val marked : substrings -> markid -> bool
 (** Tell if a mark was matched. *)
 
-val get_mark_set : substrings -> MarkSet.t
+val mark_set : substrings -> MarkSet.t
 
 (** {2 High Level Operations} *)
 

--- a/lib/re.mli
+++ b/lib/re.mli
@@ -79,6 +79,18 @@ val get_all_ofs : substrings -> (int * int) array
 val test : substrings -> int -> bool
 (** Test whether a group matched *)
 
+(** {2 Marks} *)
+
+type markid
+(** Mark id *)
+
+module MarkSet : Set.S with type elt = markid
+
+val marked : substrings -> markid -> bool
+(** Tell if a mark was matched. *)
+
+val get_mark_set : substrings -> MarkSet.t
+
 (** {2 High Level Operations} *)
 
 type 'a gen = unit -> 'a option
@@ -261,6 +273,11 @@ val no_group : t -> t
 val nest : t -> t
 (** when matching against [nest e], only the group matching in the
        last match of e will be considered as matching *)
+
+
+
+val mark : t -> markid * t
+(** Mark a regexp. the markid can then be used to know if this regexp was used. *)
 
 (** {2 Character sets} *)
 

--- a/lib/re_automata.ml
+++ b/lib/re_automata.ml
@@ -201,7 +201,7 @@ let rec rename ids x =
 
 type hash = int
 type mark_infos = int array
-type status = [`Failed | `Match of mark_infos | `Running]
+type status = Failed | Match of mark_infos | Running
 type state = int * category * e list * status option ref * hash
 
 let dummy_state = (-1, -1, [], ref None, -1)
@@ -648,9 +648,9 @@ let status (_, _, desc, status, _) =
   | None ->
       let st =
         match desc with
-          []            -> `Failed
-        | TMatch m :: _ -> `Match (flatten_match m)
-        | _             -> `Running
+          []            -> Failed
+        | TMatch m :: _ -> Match (flatten_match m)
+        | _             -> Running
       in
       status := Some st;
       st

--- a/lib/re_automata.mli
+++ b/lib/re_automata.mli
@@ -73,7 +73,7 @@ val print_state : Format.formatter -> e list -> unit
 
 type hash
 type mark_infos = int array
-type status = [`Failed | `Match of mark_infos | `Running]
+type status = Failed | Match of mark_infos | Running
 type state =
   idx * category * e list * status option ref * hash
 val dummy_state : state

--- a/lib_test/fort_unit.ml
+++ b/lib_test/fort_unit.ml
@@ -21,6 +21,8 @@ let collected_tests = ref []
 let id x = x
 let not_found () = raise Not_found
 
+let bool_printer i = Printf.sprintf "%b" i
+let int_printer i = Printf.sprintf "%d" i
 let str_printer s = "\"" ^ String.escaped s ^ "\""
 let ofs_printer (i0,i1) = Printf.sprintf "(%d,%d)" i0 i1
 let list_printer f l =

--- a/lib_test/test_re.ml
+++ b/lib_test/test_re.ml
@@ -31,14 +31,14 @@ let correct_mark ?pos ?len r s il1 il2 =
 
 (* Substring Extraction *)
 
-let _ = 
+let _ =
   let r =
-     seq [group (char 'a'); 
-          opt   (group (char 'a')); 
+     seq [group (char 'a');
+          opt   (group (char 'a'));
           group (char 'b')]
   in
   let m = exec (compile r) "ab" in
-  
+
   expect_pass "get" (fun () ->
     expect_eq_str id        "ab" (get m) 0;
     expect_eq_str id        "a"  (get m) 1;
@@ -322,8 +322,8 @@ let _ =
 
   expect_pass "group" (fun () ->
     let r =
-       seq [group (char 'a'); 
-            opt   (group (char 'a')); 
+       seq [group (char 'a');
+            opt   (group (char 'a'));
             group (char 'b')]
     in
     expect_eq_arr_ofs
@@ -334,8 +334,8 @@ let _ =
   expect_pass "no_group" (fun () ->
     let r =
        no_group (
-         seq [group (char 'a'); 
-              opt   (group (char 'a')); 
+         seq [group (char 'a');
+              opt   (group (char 'a'));
               group (char 'b')]
        )
     in

--- a/lib_test/test_re.ml
+++ b/lib_test/test_re.ml
@@ -17,6 +17,18 @@ let re_fail ?pos ?len r s =
     (fun () -> get_all_ofs (exec ?pos ?len (compile r) s)) ()
 ;;
 
+let correct_mark ?pos ?len r s il1 il2 =
+  expect_equal_app
+    ~msg:(str_printer s)
+    ~printer:bool_printer
+    id true
+    (fun () ->
+       let subs = exec ?pos ?len (compile r) s in
+       List.for_all (marked subs) il1 &&
+       List.for_all (fun x -> not @@ marked subs x) il2
+    ) ()
+;;
+
 (* Substring Extraction *)
 
 let _ = 
@@ -338,6 +350,33 @@ let _ =
     in
     re_match r "ab" [|(0,2); (-1, -1)|];
     re_match r "ba" [|(0,2); (1, 2)|];
+  );
+
+  expect_pass "mark" (fun () ->
+    let i, r = mark digit in
+    correct_mark r "0" [i] [];
+  );
+
+  expect_pass "mark seq" (fun () ->
+    let i, r = mark digit in
+    let r = seq [r; r] in
+    correct_mark r "02" [i] [] ;
+  );
+
+  expect_pass "mark rep" (fun () ->
+    let i, r = mark digit in
+    let r = rep r in
+    correct_mark r "02" [i] [];
+  );
+
+  expect_pass "mark alt" (fun () ->
+    let ia, ra = mark @@ char 'a' in
+    let ib, rb = mark @@ char 'b' in
+    let r = alt [ra ; rb] in
+    correct_mark r "a" [ia] [ib];
+    correct_mark r "b" [ib] [ia];
+    let r = rep r in
+    correct_mark r "ab" [ia; ib] [] ;
   );
 
   (* Character set *)


### PR DESCRIPTION
Path marks allow to mark a specific regexp and receive a mark
identifier. Once you have matched the regexp, you can know if the marked
regexp was used.

There is a bit of clean up first to turn some structural typing into actual typing. It makes the editing much simpler.