### PR TITLE
Add the Group and Mark modules

### DIFF
--- a/lib/re.ml
+++ b/lib/re.ml
@@ -52,8 +52,6 @@ type match_info =
   | Failed
   | Running
 
-type markid = MarkSet.elt
-
 type state =
   { idx : int;
         (* Index of the current position in the position table.
@@ -432,7 +430,7 @@ type regexp =
   | Intersection of regexp list
   | Complement of regexp list
   | Difference of regexp * regexp
-  | Pmark of markid * regexp
+  | Pmark of Automata.Pmark.t * regexp
 
 let rec is_charset r =
   match r with
@@ -1032,6 +1030,23 @@ module Group = struct
 
 end
 
+module Mark = struct
+
+  type t = Automata.Pmark.t
+
+  let test {pmarks} p =
+    Automata.PmarkSet.mem p pmarks
+
+  let all s = s.pmarks
+
+  module Set = MarkSet
+
+  let equal = Automata.Pmark.equal
+
+  let compare = Automata.Pmark.compare
+
+end
+
 type 'a gen = unit -> 'a option
 
 let all_gen ?(pos=0) ?len re s =
@@ -1201,11 +1216,6 @@ let replace_string ?pos ?len ?all re ~by s =
   replace ?pos ?len ?all re s ~f:(fun _ -> by)
 
 
-let marked {pmarks} p =
-  Automata.PmarkSet.mem p pmarks
-
-let mark_set s = s.pmarks
-
 
 (** {2 Deprecated functions} *)
 
@@ -1217,6 +1227,10 @@ let get_all = Group.all
 let get_all_ofs = Group.all_offset
 let test = Group.test
 
+type markid = Mark.t
+
+let marked = Mark.test
+let mark_set = Mark.all
 
 (**********************************)
 

--- a/lib/re.mli
+++ b/lib/re.mli
@@ -97,17 +97,24 @@ module Group : sig
 
 end
 
-(** {2 Marks} *)
+(** Marks *)
+module Mark : sig
 
-type markid
-(** Mark id *)
+  type t
+  (** Mark id *)
 
-module MarkSet : Set.S with type elt = markid
+  val test : Match.t -> t -> bool
+  (** Tell if a mark was matched. *)
 
-val marked : Group.t -> markid -> bool
-(** Tell if a mark was matched. *)
+  module Set : Set.S with type elt = t
 
-val mark_set : Group.t -> MarkSet.t
+  val all : Match.t -> Set.t
+  (** Return all the mark matched. *)
+
+  val equal : t -> t -> bool
+  val compare : t -> t -> int
+
+end
 
 (** {2 High Level Operations} *)
 
@@ -294,7 +301,7 @@ val nest : t -> t
 
 
 
-val mark : t -> markid * t
+val mark : t -> Mark.t * t
 (** Mark a regexp. the markid can then be used to know if this regexp was used. *)
 
 (** {2 Character sets} *)
@@ -371,3 +378,12 @@ val get_all_ofs : Group.t -> (int * int) array
 
 val test : Group.t -> int -> bool
 (** Same as {!Group.test}. Deprecated *)
+
+type markid = Mark.t
+(** Alias for {!Mark.t}. Deprecated *)
+
+val marked : Group.t -> Mark.t -> bool
+(** Same as {!Mark.test}. Deprecated *)
+
+val mark_set : Group.t -> Mark.Set.t
+(** Same as {!Mark.all}. Deprecated *)

--- a/lib/re.mli
+++ b/lib/re.mli
@@ -103,12 +103,12 @@ module Mark : sig
   type t
   (** Mark id *)
 
-  val test : Match.t -> t -> bool
+  val test : Group.t -> t -> bool
   (** Tell if a mark was matched. *)
 
   module Set : Set.S with type elt = t
 
-  val all : Match.t -> Set.t
+  val all : Group.t -> Set.t
   (** Return all the mark matched. *)
 
   val equal : t -> t -> bool

--- a/lib/re_pcre.mli
+++ b/lib/re_pcre.mli
@@ -2,7 +2,7 @@ type regexp = Re.re
 
 type flag = [ `CASELESS | `MULTILINE | `ANCHORED ]
 
-type substrings = Re.substrings
+type groups = Re.groups
 
 (** Result of a {!Pcre.full_split} *)
 type split_result =
@@ -17,11 +17,11 @@ val regexp : ?flags:(flag list) -> string -> regexp
 
 val extract : rex:regexp -> string -> string array
 
-val exec : rex:regexp -> ?pos:int -> string -> substrings
+val exec : rex:regexp -> ?pos:int -> string -> groups
 
-val get_substring : substrings -> int -> string
+val get_substring : groups -> int -> string
 
-val get_substring_ofs : substrings -> int -> int * int
+val get_substring_ofs : groups -> int -> int * int
 
 val pmatch : rex:regexp -> string -> bool
 
@@ -32,3 +32,7 @@ val full_split : ?max:int -> rex:regexp -> string -> split_result list
 val split : rex:regexp -> string -> string list
 
 val quote : string -> string
+
+(** {2 Deprecated} *)
+
+type substrings = Re.groups

--- a/lib/re_str.ml
+++ b/lib/re_str.ml
@@ -59,7 +59,7 @@ let search_forward re s p =
   try
     let res = Re.exec ~pos:p (get_srch re) s in
     state := Some res;
-    fst (Re.get_ofs res 0)
+    fst (Re.Group.offset res 0)
   with Not_found ->
     state := None;
     raise Not_found
@@ -76,12 +76,12 @@ let rec search_backward re s p =
 
 let beginning_group i =
   match !state with
-    Some m -> fst (Re.get_ofs m i)
+    Some m -> fst (Re.Group.offset m i)
   | None   -> raise Not_found
 
 let end_group i =
   match !state with
-    Some m -> snd (Re.get_ofs m i)
+    Some m -> snd (Re.Group.offset m i)
   | None   -> raise Not_found
 
 let get_len i =
@@ -89,7 +89,7 @@ let get_len i =
     None   -> 0
   | Some m ->
       try
-        let (b, e) = Re.get_ofs m i in
+        let (b, e) = Re.Group.offset m i in
         e - b
       with Not_found ->
         0
@@ -131,7 +131,7 @@ let rec replace orig repl p res q len =
                 None ->
                   raise Not_found
               | Some m ->
-                  let (b, e) = Re.get_ofs m (Char.code c - Char.code '0') in
+                  let (b, e) = Re.Group.offset m (Char.code c - Char.code '0') in
                   let d = e - b in
                   if d > 0 then String.blit orig b res q d;
                   d

--- a/lib_test/re_match.ml
+++ b/lib_test/re_match.ml
@@ -38,7 +38,7 @@ let check_phone cnt must_print line =
   try
     let matches = Re.exec rex line in
     let num = String.copy "(...) ...-...."
-    and (pos, _) = Re.get_ofs matches 1 in
+    and (pos, _) = Re.Group.offset matches 1 in
     let ofs = if line.[pos] = '(' then 1 else 0 in
     let pos = pos + ofs in
     String.blit line pos num 1 3;

--- a/lib_test/test_easy.ml
+++ b/lib_test/test_easy.ml
@@ -33,7 +33,7 @@ let map_split_delim =
   List.map
     (function
       | `Text x -> `T x
-      | `Delim s -> `D (Re.get s 0)
+      | `Delim s -> `D (Re.Group.get s 0)
     )
 
 let pp_list' l =
@@ -63,7 +63,7 @@ let test_split_full () =
 
 let test_replace () =
   let re = Re_posix.compile_pat "[a-zA-Z]+" in
-  let f sub = String.capitalize (Re.get sub 0) in
+  let f sub = String.capitalize (Re.Group.get sub 0) in
   assert_equal ~printer:pp_str  " Hello World; I Love Chips!"
     (Re.replace re ~f " hello world; I love chips!");
   assert_equal ~printer:pp_str " Allo maman, bobo"

--- a/lib_test/test_re.ml
+++ b/lib_test/test_re.ml
@@ -6,7 +6,7 @@ let re_match ?pos ?len r s res =
     ~msg:(str_printer s)
     ~printer:arr_ofs_printer
     id res
-    (fun () -> get_all_ofs (exec ?pos ?len (compile r) s)) ()
+    (fun () -> Group.all_offset (exec ?pos ?len (compile r) s)) ()
 ;;
 
 let re_fail ?pos ?len r s =
@@ -14,7 +14,7 @@ let re_fail ?pos ?len r s =
     ~msg:(str_printer s)
     ~printer:arr_ofs_printer
     not_found ()
-    (fun () -> get_all_ofs (exec ?pos ?len (compile r) s)) ()
+    (fun () -> Group.all_offset (exec ?pos ?len (compile r) s)) ()
 ;;
 
 let correct_mark ?pos ?len r s il1 il2 =
@@ -39,40 +39,40 @@ let _ =
   in
   let m = exec (compile r) "ab" in
 
-  expect_pass "get" (fun () ->
-    expect_eq_str id        "ab" (get m) 0;
-    expect_eq_str id        "a"  (get m) 1;
-    expect_eq_str not_found ()   (get m) 2;
-    expect_eq_str id        "b"  (get m) 3;
-    expect_eq_str not_found ()   (get m) 4;
+  expect_pass "Group.get" (fun () ->
+    expect_eq_str id        "ab" (Group.get m) 0;
+    expect_eq_str id        "a"  (Group.get m) 1;
+    expect_eq_str not_found ()   (Group.get m) 2;
+    expect_eq_str id        "b"  (Group.get m) 3;
+    expect_eq_str not_found ()   (Group.get m) 4;
   );
 
-  expect_pass "get_ofs" (fun () ->
-    expect_eq_ofs id        (0,2) (get_ofs m) 0;
-    expect_eq_ofs id        (0,1) (get_ofs m) 1;
-    expect_eq_ofs not_found ()    (get_ofs m) 2;
-    expect_eq_ofs id        (1,2) (get_ofs m) 3;
-    expect_eq_ofs not_found ()    (get_ofs m) 4;
+  expect_pass "Group.offset" (fun () ->
+    expect_eq_ofs id        (0,2) (Group.offset m) 0;
+    expect_eq_ofs id        (0,1) (Group.offset m) 1;
+    expect_eq_ofs not_found ()    (Group.offset m) 2;
+    expect_eq_ofs id        (1,2) (Group.offset m) 3;
+    expect_eq_ofs not_found ()    (Group.offset m) 4;
   );
 
-  expect_pass "get_all" (fun () ->
+  expect_pass "Group.all" (fun () ->
     expect_eq_arr_str
       id [|"ab";"a";"";"b"|]
-      get_all m
+      Group.all m
   );
 
-  expect_pass "get_all_ofs" (fun () ->
+  expect_pass "Group.all_offset" (fun () ->
     expect_eq_arr_ofs
       id [|(0,2);(0,1);(-1,-1);(1,2)|]
-      get_all_ofs m
+      Group.all_offset m
   );
 
-  expect_pass "test" (fun () ->
-    expect_eq_bool id true (test m) 0;
-    expect_eq_bool id true (test m) 1;
-    expect_eq_bool id false (test m) 2;
-    expect_eq_bool id true (test m) 3;
-    expect_eq_bool id false (test m) 4;
+  expect_pass "Group.test" (fun () ->
+    expect_eq_bool id true (Group.test m) 0;
+    expect_eq_bool id true (Group.test m) 1;
+    expect_eq_bool id false (Group.test m) 2;
+    expect_eq_bool id true (Group.test m) 3;
+    expect_eq_bool id false (Group.test m) 4;
   );
 
   (* Literal Match *)
@@ -328,7 +328,7 @@ let _ =
     in
     expect_eq_arr_ofs
       id [|(0,2);(0,1);(-1,-1);(1,2)|]
-      (fun () -> get_all_ofs (exec (compile r) "ab")) ()
+      (fun () -> Group.all_offset (exec (compile r) "ab")) ()
   );
 
   expect_pass "no_group" (fun () ->
@@ -341,7 +341,7 @@ let _ =
     in
     expect_eq_arr_ofs
       id [|(0,2)|]
-      (fun () -> get_all_ofs (exec (compile r) "ab")) ()
+      (fun () -> Group.all_offset (exec (compile r) "ab")) ()
   );
 
   expect_pass "nest" (fun () ->

--- a/lib_test/test_re.ml
+++ b/lib_test/test_re.ml
@@ -24,8 +24,8 @@ let correct_mark ?pos ?len r s il1 il2 =
     id true
     (fun () ->
        let subs = exec ?pos ?len (compile r) s in
-       List.for_all (marked subs) il1 &&
-       List.for_all (fun x -> not (marked subs x)) il2
+       List.for_all (Mark.test subs) il1 &&
+       List.for_all (fun x -> not (Mark.test subs x)) il2
     ) ()
 ;;
 

--- a/lib_test/test_str.ml
+++ b/lib_test/test_str.ml
@@ -14,7 +14,7 @@ let eq_match ?pos ?len ?(case = true) r s =
        let n_groups =
          try
            let m = Re.exec ~pos ?len (Re.compile (Re_emacs.re ~case r)) s in
-           Array.length (Re.get_all_ofs m)
+           Array.length (Re.Group.all_offset m)
          with _ -> 0
        in
 
@@ -29,7 +29,7 @@ let eq_match ?pos ?len ?(case = true) r s =
        get_all_ofs 0 []
     ) ()
     (fun () ->
-       Re.get_all_ofs (
+       Re.Group.all_offset (
          Re.exec ?pos ?len (Re_emacs.compile (Re_emacs.re ~case r)) s
        )
     ) ()
@@ -166,4 +166,3 @@ let _ =
   );
 
   run_test_suite "test_str"
-


### PR DESCRIPTION
As discussed in #43

I though that "Group" was a better name (consider Group.get, Group.all, Group.test). I'm sure we will bikeshed the names thoroughly, though. :)
I also added the Mark module.

I'll probably drop the commit with the deprecation warnings, but it was nice to have them.