### PR TITLE
Prefer optional arguments instead of multiple glob functions

### DIFF
--- a/lib/re_glob.ml
+++ b/lib/re_glob.ml
@@ -105,7 +105,7 @@ let glob_parse ?(anchored=false) init s =
   let res = expr () in
   if anchored then Re.whole_string res else res
 
-let rec mul l l' =
+let mul l l' =
   List.flatten (List.map (fun s -> List.map (fun s' -> s ^ s') l') l)
 
 let explode str =
@@ -131,9 +131,20 @@ let explode str =
   in
   List.rev (fst (expl false 0 0 [] [""]))
 
-let glob' ?anchored nodot s =
-  glob_parse ?anchored (if nodot then Beg else Mid) s
-let glob ?anchored s = glob' ?anchored true s
-let globx' ?anchored nodot s =
-  Re.alt (List.map (glob' ?anchored nodot) (explode s))
-let globx ?anchored s = globx' ?anchored true s
+let glob ?anchored ?(period = true) ?(expand_braces = false) s =
+  let init_state =
+    if period
+    then Beg
+    else Mid
+  in
+  let parse s = glob_parse ?anchored init_state s in
+  if expand_braces
+  then Re.alt (List.map parse (explode s))
+  else parse s
+;;
+
+let glob' ?anchored period s = glob ?anchored ~period s
+
+let globx ?anchored s = glob ?anchored ~expand_braces:true s
+
+let globx' ?anchored period s = glob ?anchored ~period ~expand_braces:true s

--- a/lib/re_glob.mli
+++ b/lib/re_glob.mli
@@ -34,13 +34,13 @@ val glob :
     expression is unanchored by default.
 
     [anchored] controls whether the regular expression will only match entire
-    strings.
+    strings. It defaults to false.
 
     [period] controls whether a dot at the beginning of a file
-    name must be explicitly matched.
+    name must be explicitly matched. It's true by default.
 
     If [expand_braces] is true, braced sets will expand into multiple globs,
-    e.g. a\{x,y\}b\{1,2\} matches axb1, axb2, ayb1, ayb2.
+    e.g. a\{x,y\}b\{1,2\} matches axb1, axb2, ayb1, ayb2. It defaults to false.
 
     Character '/' must be explicitly matched.
     Character '*' matches any sequence of characters and character

--- a/lib/re_glob.mli
+++ b/lib/re_glob.mli
@@ -24,23 +24,47 @@
 
 exception Parse_error
 
-val glob : ?anchored:bool -> string -> Re.t
+val glob :
+  ?anchored:bool ->
+  ?period:bool ->
+  ?expand_braces:bool ->
+  string ->
+  Re.t
 (** Implements the semantics of shells patterns. The returned regular
-    expression is unanchored by default. If the [anchored] parameter
-    is provided, the regular expression will only matches whole strings.
+    expression is unanchored by default.
 
-    Character '/' must be explicitely matched.  A dot at the
-    beginning of a file name must be explicitely matched as well.
+    [anchored] controls whether the regular expression will only match entire
+    strings.
+
+    [period] controls whether a dot at the beginning of a file
+    name must be explicitly matched.
+
+    If [expand_braces] is true, braced sets will expand into multiple globs,
+    e.g. a\{x,y\}b\{1,2\} matches axb1, axb2, ayb1, ayb2.
+
+    Character '/' must be explicitly matched.
     Character '*' matches any sequence of characters and character
     '?' matches a single character, provided these restrictions are
-    satisfied,
+    satisfied.
     A sequence '[...]' matches any of the enclosed characters.
-    A backslash escapes the following character. *)
+    A backslash escapes the following character.
+*)
 
 val glob' : ?anchored:bool -> bool -> string -> Re.t
 (** Same, but allows to choose whether dots at the beginning of a
-    file name need to be explicitly matched (true) or not (false) *)
+    file name need to be explicitly matched (true) or not (false)
+
+    @deprecated Use [glob] with the optional [period] parameter.
+*)
 
 val globx : ?anchored:bool -> string -> Re.t
+(** This version of [glob] also recognizes the pattern \{..,..\}
+
+    @deprecated Prefer [glob ~expand_braces:true].
+*)
+
 val globx' : ?anchored:bool -> bool -> string -> Re.t
-(** These two functions also recognize the pattern \{..,..\} *)
+(** This version of [glob'] also recognizes the pattern \{..,..\}
+
+    @deprecated Prefer [glob ~expand_braces:true ?period].
+*)

--- a/lib_test/test_glob.ml
+++ b/lib_test/test_glob.ml
@@ -1,4 +1,5 @@
 open Re_glob
+open Fort_unit
 
 let re_match ?pos ?len re s =
   Re.execp ?pos ?len (Re.compile re) s
@@ -48,10 +49,12 @@ let _ =
   assert (re_match    (glob "{foo,bar}bar") "{foo,bar}bar");
   assert (re_mismatch (glob "foo?bar"     ) "foo/bar"     );
 
-  assert (re_mismatch (glob' true  "?oobar") ".oobar");
-  assert (re_mismatch (glob        "?oobar") ".oobar");
-  assert (re_match    (glob' false "?oobar") ".oobar");
+  assert (re_mismatch (glob ~period:true  "?oobar") ".oobar");
+  assert (re_mismatch (glob               "?oobar") ".oobar");
+  assert (re_match    (glob ~period:false "?oobar") ".oobar");
 
-  assert (re_match    (globx "{foo,far}bar") "foobar"      );
-  assert (re_match    (globx "{foo,far}bar") "farbar"      );
-  assert (re_mismatch (globx "{foo,far}bar") "{foo,far}bar");
+  assert (re_match    (glob ~expand_braces:true "{foo,far}bar") "foobar"      );
+  assert (re_match    (glob ~expand_braces:true "{foo,far}bar") "farbar"      );
+  assert (re_mismatch (glob ~expand_braces:true "{foo,far}bar") "{foo,far}bar");
+
+  run_test_suite "test_re";


### PR DESCRIPTION
The glob API now exposes a single function with multiple optional arguments, rather than having several similarly-named functions with slightly different functionality.