### PR TITLE
Rewrite glob code, with support for not explicitly matching slashes.

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -1,3 +1,5 @@
+set -e
+
 OPAM_DEPENDS="ounit"
 
 case "$OCAML_VERSION,$OPAM_VERSION" in
@@ -33,3 +35,6 @@ opam pin add re .
 # run tests
 ./configure --enable-tests
 make test
+
+# Check that there's no new diff
+git status

--- a/lib/re_glob.ml
+++ b/lib/re_glob.ml
@@ -90,11 +90,9 @@ let of_string s : t =
   in
 
   loop []
-;;
 
 let mul l l' =
   List.flatten (List.map (fun s -> List.map (fun s' -> s ^ s') l') l)
-;;
 
 let explode str =
   let l = String.length str in
@@ -118,7 +116,6 @@ let explode str =
         expl inner s (i + 1) acc beg
   in
   List.rev (fst (expl false 0 0 [] [""]))
-;;
 
 module To_re = struct
   module State = struct
@@ -136,20 +133,17 @@ module To_re = struct
         explicit_matching;
         remaining;
       }
-    ;;
 
     let explicit_matching t =
       match t.am_at_start_of_component, t.explicit_matching with
       | false, `Slashes_and_leading_dots -> `Slashes
       | _, other -> other
-    ;;
 
     let append ?(am_at_start_of_component=false) t piece =
       { t with
         re_pieces = piece :: t.re_pieces;
         am_at_start_of_component;
       }
-    ;;
 
     let to_re t = Re.seq (List.rev t.re_pieces)
 
@@ -157,7 +151,6 @@ module To_re = struct
       match t.remaining with
       | [] -> None
       | piece :: remaining -> Some (piece, { t with remaining })
-    ;;
   end
 
   let one ~explicit_matching =
@@ -165,13 +158,11 @@ module To_re = struct
     | `None -> Re.any
     | `Slashes -> Re.(compl [char '/'])
     | `Slashes_and_leading_dots -> Re.(compl [char '/'; char '.'])
-  ;;
 
   let enclosed enclosed =
     match enclosed with
     | Char c -> Re.char c
     | Range (low, high) -> Re.rg low high
-  ;;
 
   let enclosed_set ~explicit_matching kind set =
     let set = List.map enclosed set in
@@ -181,11 +172,9 @@ module To_re = struct
       | `AnyBut -> Re.compl set
     in
     Re.inter [enclosure; one ~explicit_matching]
-  ;;
 
   let exactly state c =
     State.append state (Re.char c) ~am_at_start_of_component:(c = '/')
-  ;;
 
   let many (state : State.t) =
     match State.explicit_matching state with
@@ -229,7 +218,6 @@ module To_re = struct
         | Some (Any_but enclosed, state) -> enclosed_set state `AnyBut enclosed
       in
       lookahead state
-  ;;
 
   let piece state piece =
     let explicit_matching = State.explicit_matching state in
@@ -241,7 +229,6 @@ module To_re = struct
     | Any_but enclosed ->
       State.append state (enclosed_set `AnyBut ~explicit_matching enclosed)
     | Exactly c -> exactly state c
-  ;;
 
   let glob ~explicit_matching glob =
     let rec loop state =
@@ -250,7 +237,6 @@ module To_re = struct
       | Some (p, state) -> loop (piece state p)
     in
     loop (State.create ~explicit_matching glob)
-  ;;
 end
 
 let glob

--- a/lib/re_glob.ml
+++ b/lib/re_glob.ml
@@ -168,8 +168,8 @@ module To_re = struct
     let set = List.map enclosed set in
     let enclosure =
       match kind with
-      | `AnyOf -> Re.alt set
-      | `AnyBut -> Re.compl set
+      | `Any_of -> Re.alt set
+      | `Any_but -> Re.compl set
     in
     Re.inter [enclosure; one ~explicit_matching]
 
@@ -214,8 +214,8 @@ module To_re = struct
           exactly state c
         (* glob *? === glob ?* *)
         | Some (One, state) -> State.append state not_empty
-        | Some (Any_of enclosed, state) -> enclosed_set state `AnyOf enclosed
-        | Some (Any_but enclosed, state) -> enclosed_set state `AnyBut enclosed
+        | Some (Any_of enclosed, state) -> enclosed_set state `Any_of enclosed
+        | Some (Any_but enclosed, state) -> enclosed_set state `Any_but enclosed
       in
       lookahead state
 
@@ -225,9 +225,9 @@ module To_re = struct
     | One -> State.append state (one ~explicit_matching)
     | Many -> many state
     | Any_of enclosed ->
-      State.append state (enclosed_set `AnyOf ~explicit_matching enclosed)
+      State.append state (enclosed_set `Any_of ~explicit_matching enclosed)
     | Any_but enclosed ->
-      State.append state (enclosed_set `AnyBut ~explicit_matching enclosed)
+      State.append state (enclosed_set `Any_but ~explicit_matching enclosed)
     | Exactly c -> exactly state c
 
   let glob ~explicit_matching glob =

--- a/lib/re_glob.ml
+++ b/lib/re_glob.ml
@@ -101,170 +101,168 @@ let explode str =
       if inner then raise Parse_error;
       (mul beg [String.sub str s (i - s)], i)
     end else
-    match str.[i] with
-    | '\\' -> expl inner s (i + 2) acc beg
-    | '{' ->
+      match str.[i] with
+      | '\\' -> expl inner s (i + 2) acc beg
+      | '{' ->
         let (t, i') = expl true (i + 1) (i + 1) [] [""] in
         expl inner i' i' acc
           (mul beg (mul [String.sub str s (i - s)] t))
-    | ',' when inner ->
+      | ',' when inner ->
         expl inner (i + 1) (i + 1)
           (mul beg [String.sub str s (i - s)] @ acc) [""]
-    | '}' when inner ->
+      | '}' when inner ->
         (mul beg [String.sub str s (i - s)] @ acc, i + 1)
-    | _ ->
+      | _ ->
         expl inner s (i + 1) acc beg
   in
   List.rev (fst (expl false 0 0 [] [""]))
 
-module To_re = struct
-  module State = struct
-    type t = {
-      re_pieces                : Re.t list;  (* last piece at head of list. *)
-      remaining                : piece list; (* last piece at tail of list. *)
-      am_at_start_of_pattern   : bool;       (* true at start of pattern *)
-      am_at_start_of_component : bool;       (* true at start of pattern or immediately
-                                                after '/' *)
-      pathname                 : bool;
-      period                   : bool;
+module State = struct
+  type t = {
+    re_pieces                : Re.t list;  (* last piece at head of list. *)
+    remaining                : piece list; (* last piece at tail of list. *)
+    am_at_start_of_pattern   : bool;       (* true at start of pattern *)
+    am_at_start_of_component : bool;       (* true at start of pattern or immediately
+                                              after '/' *)
+    pathname                 : bool;
+    period                   : bool;
+  }
+
+  let create ~period ~pathname remaining =
+    {
+      re_pieces = [];
+      am_at_start_of_pattern = true;
+      am_at_start_of_component = true;
+      pathname;
+      period;
+      remaining;
     }
 
-    let create ~period ~pathname remaining =
-      {
-        re_pieces = [];
-        am_at_start_of_pattern = true;
-        am_at_start_of_component = true;
-        pathname;
-        period;
-        remaining;
-      }
+  let explicit_period t =
+    t.period && (
+      t.am_at_start_of_pattern ||
+      (t.am_at_start_of_component && t.pathname)
+    )
 
-    let explicit_period t =
-      t.period && (
-        t.am_at_start_of_pattern ||
-        (t.am_at_start_of_component && t.pathname)
-      )
+  let explicit_slash t = t.pathname
 
-    let explicit_slash t = t.pathname
+  let append ?(am_at_start_of_component=false) t piece =
+    { t with
+      re_pieces = piece :: t.re_pieces;
+      am_at_start_of_pattern = false;
+      am_at_start_of_component;
+    }
 
-    let append ?(am_at_start_of_component=false) t piece =
-      { t with
-        re_pieces = piece :: t.re_pieces;
-        am_at_start_of_pattern = false;
-        am_at_start_of_component;
-      }
+  let to_re t = Re.seq (List.rev t.re_pieces)
 
-    let to_re t = Re.seq (List.rev t.re_pieces)
+  let next t =
+    match t.remaining with
+    | [] -> None
+    | piece :: remaining -> Some (piece, { t with remaining })
+end
 
-    let next t =
-      match t.remaining with
-      | [] -> None
-      | piece :: remaining -> Some (piece, { t with remaining })
+let one ~explicit_slash ~explicit_period =
+  Re.(compl (
+    List.concat [
+      if explicit_slash  then [char '/'] else [];
+      if explicit_period then [char '.'] else [];
+    ]
+  ))
+
+let enclosed enclosed =
+  match enclosed with
+  | Char c -> Re.char c
+  | Range (low, high) -> Re.rg low high
+
+let enclosed_set ~explicit_slash ~explicit_period kind set =
+  let set = List.map enclosed set in
+  let enclosure =
+    match kind with
+    | `Any_of -> Re.alt set
+    | `Any_but -> Re.compl set
+  in
+  Re.inter [enclosure; one ~explicit_slash ~explicit_period]
+
+let exactly state c =
+  State.append state (Re.char c) ~am_at_start_of_component:(c = '/')
+
+let many (state : State.t) =
+  let explicit_slash = State.explicit_slash state in
+  let explicit_period = State.explicit_period state in
+  (* Whether we must explicitly match period depends on the surrounding characters, but
+     slashes are easy to explicit match. This conditional splits out some simple cases.
+  *)
+  if not explicit_period then begin
+    State.append state (Re.rep (one ~explicit_slash ~explicit_period))
+  end else if not explicit_slash then begin
+    (* In this state, we explicitly match periods only at the very beginning *)
+    Re.opt (
+      Re.seq [
+        one         ~explicit_slash:false ~explicit_period;
+        Re.rep (one ~explicit_slash:false ~explicit_period:false);
+      ]
+    )
+    |> State.append state
+  end else begin
+    let not_empty =
+      Re.seq [
+        one         ~explicit_slash:true ~explicit_period:true;
+        Re.rep (one ~explicit_slash:true ~explicit_period:false);
+      ]
+    in
+    (* [maybe_empty] is the default translation of Many, except in some special cases.
+    *)
+    let maybe_empty = Re.opt not_empty in
+    let enclosed_set state kind set =
+      State.append state (Re.alt [
+        enclosed_set kind set ~explicit_slash:true ~explicit_period:true;
+        Re.seq [
+          not_empty;
+          (* Since [not_empty] matched, subsequent dots are not leading. *)
+          enclosed_set kind set ~explicit_slash:true ~explicit_period:false;
+        ];
+      ])
+    in
+    let rec lookahead state =
+      match State.next state with
+      | None -> State.append state maybe_empty
+      (* glob ** === glob * . *)
+      | Some (Many, state) -> lookahead state
+      | Some (Exactly c, state) ->
+        let state =
+          State.append state
+            (if c = '.'
+             then not_empty
+             else maybe_empty)
+        in
+        exactly state c
+      (* glob *? === glob ?* *)
+      | Some (One, state) -> State.append state not_empty
+      | Some (Any_of enclosed, state) -> enclosed_set state `Any_of enclosed
+      | Some (Any_but enclosed, state) -> enclosed_set state `Any_but enclosed
+    in
+    lookahead state
   end
 
-  let one ~explicit_slash ~explicit_period =
-    Re.(compl (
-      List.concat [
-        if explicit_slash  then [char '/'] else [];
-        if explicit_period then [char '.'] else [];
-      ]
-    ))
+let piece state piece =
+  let explicit_slash = State.explicit_slash state in
+  let explicit_period = State.explicit_period state in
+  match piece with
+  | One -> State.append state (one ~explicit_slash ~explicit_period)
+  | Many -> many state
+  | Any_of enclosed ->
+    State.append state (enclosed_set `Any_of ~explicit_slash ~explicit_period enclosed)
+  | Any_but enclosed ->
+    State.append state (enclosed_set `Any_but ~explicit_slash ~explicit_period enclosed)
+  | Exactly c -> exactly state c
 
-  let enclosed enclosed =
-    match enclosed with
-    | Char c -> Re.char c
-    | Range (low, high) -> Re.rg low high
-
-  let enclosed_set ~explicit_slash ~explicit_period kind set =
-    let set = List.map enclosed set in
-    let enclosure =
-      match kind with
-      | `Any_of -> Re.alt set
-      | `Any_but -> Re.compl set
-    in
-    Re.inter [enclosure; one ~explicit_slash ~explicit_period]
-
-  let exactly state c =
-    State.append state (Re.char c) ~am_at_start_of_component:(c = '/')
-
-  let many (state : State.t) =
-    let explicit_slash = State.explicit_slash state in
-    let explicit_period = State.explicit_period state in
-    (* Whether we must explicitly match period depends on the surrounding characters, but
-       slashes are easy to explicit match. This conditional splits out some simple cases.
-    *)
-    if not explicit_period then begin
-      State.append state (Re.rep (one ~explicit_slash ~explicit_period))
-    end else if not explicit_slash then begin
-      (* In this state, we explicitly match periods only at the very beginning *)
-      Re.opt (
-        Re.seq [
-          one         ~explicit_slash:false ~explicit_period;
-          Re.rep (one ~explicit_slash:false ~explicit_period:false);
-        ]
-      )
-      |> State.append state
-    end else begin
-      let not_empty =
-        Re.seq [
-          one         ~explicit_slash:true ~explicit_period:true;
-          Re.rep (one ~explicit_slash:true ~explicit_period:false);
-        ]
-      in
-      (* [maybe_empty] is the default translation of Many, except in some special cases.
-      *)
-      let maybe_empty = Re.opt not_empty in
-      let enclosed_set state kind set =
-        State.append state (Re.alt [
-          enclosed_set kind set ~explicit_slash:true ~explicit_period:true;
-          Re.seq [
-            not_empty;
-            (* Since [not_empty] matched, subsequent dots are not leading. *)
-            enclosed_set kind set ~explicit_slash:true ~explicit_period:false;
-          ];
-        ])
-      in
-      let rec lookahead state =
-        match State.next state with
-        | None -> State.append state maybe_empty
-        (* glob ** === glob * . *)
-        | Some (Many, state) -> lookahead state
-        | Some (Exactly c, state) ->
-          let state =
-            State.append state
-              (if c = '.'
-               then not_empty
-               else maybe_empty)
-          in
-          exactly state c
-        (* glob *? === glob ?* *)
-        | Some (One, state) -> State.append state not_empty
-        | Some (Any_of enclosed, state) -> enclosed_set state `Any_of enclosed
-        | Some (Any_but enclosed, state) -> enclosed_set state `Any_but enclosed
-      in
-      lookahead state
-    end
-
-  let piece state piece =
-    let explicit_slash = State.explicit_slash state in
-    let explicit_period = State.explicit_period state in
-    match piece with
-    | One -> State.append state (one ~explicit_slash ~explicit_period)
-    | Many -> many state
-    | Any_of enclosed ->
-      State.append state (enclosed_set `Any_of ~explicit_slash ~explicit_period enclosed)
-    | Any_but enclosed ->
-      State.append state (enclosed_set `Any_but ~explicit_slash ~explicit_period enclosed)
-    | Exactly c -> exactly state c
-
-  let glob ~pathname ~period glob =
-    let rec loop state =
-      match State.next state with
-      | None -> State.to_re state
-      | Some (p, state) -> loop (piece state p)
-    in
-    loop (State.create ~pathname ~period glob)
-end
+let glob ~pathname ~period glob =
+  let rec loop state =
+    match State.next state with
+    | None -> State.to_re state
+    | Some (p, state) -> loop (piece state p)
+  in
+  loop (State.create ~pathname ~period glob)
 
 let glob
       ?(anchored = false)
@@ -274,7 +272,7 @@ let glob
       s
   =
   let to_re s =
-    let re = To_re.glob ~pathname ~period (of_string s) in
+    let re = glob ~pathname ~period (of_string s) in
     if anchored
     then Re.whole_string re
     else re

--- a/lib/re_glob.mli
+++ b/lib/re_glob.mli
@@ -26,7 +26,7 @@ exception Parse_error
 
 val glob :
   ?anchored:bool ->
-  ?period:bool ->
+  ?explicit_matching:[ `None | `Slashes | `Slashes_and_leading_dots ] ->
   ?expand_braces:bool ->
   string ->
   Re.t
@@ -34,27 +34,35 @@ val glob :
     expression is unanchored by default.
 
     [anchored] controls whether the regular expression will only match entire
-    strings. It defaults to false.
+    strings. Defaults to false.
 
-    [period] controls whether a dot at the beginning of a file
-    name must be explicitly matched. It's true by default.
+    [explicit_matching] determines whether wildcards *, ?, and [...] match
+    characters that have special meaning in filenames, or whether one must explicitly
+    write that character into the pattern.
+    [`None]: wildcards can match any character(s).
+    [`Slashes]: wildcards do not match slashes.
+    [`Slashes_and_leading_dots]: patterns match slashes and leading dots iff the pattern
+    has that slash or leading dot.  Leading dots are dots at the start of the string and
+    dots immediately following slashes.
+    Defaults to [`Slashes_and_leading_dots].
 
     If [expand_braces] is true, braced sets will expand into multiple globs,
-    e.g. a\{x,y\}b\{1,2\} matches axb1, axb2, ayb1, ayb2. It defaults to false.
+    e.g. a{x,y}b{1,2} matches axb1, axb2, ayb1, ayb2.  As specified for bash, brace
+    expansion is purely textual and can be nested. Defaults to false.
 
-    Character '/' must be explicitly matched.
     Character '*' matches any sequence of characters and character
-    '?' matches a single character, provided these restrictions are
-    satisfied.
-    A sequence '[...]' matches any of the enclosed characters.
-    A backslash escapes the following character.
-*)
+    '?' matches a single character.
+    A sequence '[...]' matches any one of the enclosed characters.
+    A sequence '[^...]' or '[!...]' matches any character *but* the enclosed characters.
+    A backslash escapes the following character.  The last character of the string cannot
+    be a backslash. *)
 
 val glob' : ?anchored:bool -> bool -> string -> Re.t
 (** Same, but allows to choose whether dots at the beginning of a
     file name need to be explicitly matched (true) or not (false)
 
-    @deprecated Use [glob] with the optional [period] parameter.
+    @deprecated Use [glob] with [~explicit_matching:`Slashes] or
+    [~explicit_matching:`Slashes_and_leading_dots].
 *)
 
 val globx : ?anchored:bool -> string -> Re.t
@@ -66,5 +74,6 @@ val globx : ?anchored:bool -> string -> Re.t
 val globx' : ?anchored:bool -> bool -> string -> Re.t
 (** This version of [glob'] also recognizes the pattern \{..,..\}
 
-    @deprecated Prefer [glob ~expand_braces:true ?period].
+    @deprecated Prefer [glob ~expand_braces:true ~explicit_matching:`Slashes] or
+    [glob ~expand_braces:true ~explicit_matching:`Slashes_and_leading_dots].
 *)

--- a/lib/re_glob.mli
+++ b/lib/re_glob.mli
@@ -26,43 +26,42 @@ exception Parse_error
 
 val glob :
   ?anchored:bool ->
-  ?explicit_matching:[ `None | `Slashes | `Slashes_and_leading_dots ] ->
+  ?pathname:bool ->
+  ?period:bool ->
   ?expand_braces:bool ->
   string ->
   Re.t
 (** Implements the semantics of shells patterns. The returned regular
     expression is unanchored by default.
 
-    [anchored] controls whether the regular expression will only match entire
-    strings. Defaults to false.
-
-    [explicit_matching] determines whether wildcards *, ?, and [...] match
-    characters that have special meaning in filenames, or whether one must explicitly
-    write that character into the pattern.
-    [`None]: wildcards can match any character(s).
-    [`Slashes]: wildcards do not match slashes.
-    [`Slashes_and_leading_dots]: patterns match slashes and leading dots iff the pattern
-    has that slash or leading dot.  Leading dots are dots at the start of the string and
-    dots immediately following slashes.
-    Defaults to [`Slashes_and_leading_dots].
-
-    If [expand_braces] is true, braced sets will expand into multiple globs,
-    e.g. a{x,y}b{1,2} matches axb1, axb2, ayb1, ayb2.  As specified for bash, brace
-    expansion is purely textual and can be nested. Defaults to false.
-
     Character '*' matches any sequence of characters and character
     '?' matches a single character.
     A sequence '[...]' matches any one of the enclosed characters.
     A sequence '[^...]' or '[!...]' matches any character *but* the enclosed characters.
     A backslash escapes the following character.  The last character of the string cannot
-    be a backslash. *)
+    be a backslash.
+
+    [anchored] controls whether the regular expression will only match entire
+    strings. Defaults to false.
+
+    [pathname]: If this flag is set, match a slash in string only with a slash in pattern
+    and not by an asterisk ('*') or a question mark ('?') metacharacter, nor by a bracket
+    expression ('[]') containing a slash. Defaults to true.
+
+    [period]: If this flag is set, a leading period in string has to be matched exactly by
+    a period in pattern. A period is considered to be leading if it is the first
+    character in string, or if both [pathname] is set and the period immediately follows a
+    slash. Defaults to true.
+
+    If [expand_braces] is true, braced sets will expand into multiple globs,
+    e.g. a{x,y}b{1,2} matches axb1, axb2, ayb1, ayb2.  As specified for bash, brace
+    expansion is purely textual and can be nested. Defaults to false. *)
 
 val glob' : ?anchored:bool -> bool -> string -> Re.t
 (** Same, but allows to choose whether dots at the beginning of a
     file name need to be explicitly matched (true) or not (false)
 
-    @deprecated Use [glob] with [~explicit_matching:`Slashes] or
-    [~explicit_matching:`Slashes_and_leading_dots].
+    @deprecated Use [glob ~period].
 *)
 
 val globx : ?anchored:bool -> string -> Re.t
@@ -74,6 +73,5 @@ val globx : ?anchored:bool -> string -> Re.t
 val globx' : ?anchored:bool -> bool -> string -> Re.t
 (** This version of [glob'] also recognizes the pattern \{..,..\}
 
-    @deprecated Prefer [glob ~expand_braces:true ~explicit_matching:`Slashes] or
-    [glob ~expand_braces:true ~explicit_matching:`Slashes_and_leading_dots].
+    @deprecated Prefer [glob ~expand_braces:true ~period].
 *)

--- a/lib_test/glob.ml
+++ b/lib_test/glob.ml
@@ -13,7 +13,7 @@ let printf      = Printf.printf
 let (@@) f x    = f x
 
 let glob pattern str =
-    let rx = R.compile @@ R.whole_string @@ G.globx pattern in
+    let rx = R.compile @@ R.whole_string @@ G.glob ~expand_braces:true pattern in
     (* let () = R.print_re Format.std_formatter rx in *)
     if R.execp rx str
     then printf "%s matches:       %s\n" pattern str
@@ -21,13 +21,13 @@ let glob pattern str =
 
 let main () =
     let argv = Array.to_list Sys.argv in
-    let this = List.hd argv in 
+    let this = List.hd argv in
     let args = List.tl argv in
         match args with
         | [] | [_]   -> error "usage: %s pattern string .." this
         | p :: strs  -> List.iter (glob p) strs
 
-let () = 
+let () =
     try
         main (); exit 0
     with

--- a/lib_test/test_glob.ml
+++ b/lib_test/test_glob.ml
@@ -49,9 +49,28 @@ let _ =
   assert (re_match    (glob "{foo,bar}bar") "{foo,bar}bar");
   assert (re_mismatch (glob "foo?bar"     ) "foo/bar"     );
 
-  assert (re_mismatch (glob ~period:true  "?oobar") ".oobar");
-  assert (re_mismatch (glob               "?oobar") ".oobar");
-  assert (re_match    (glob ~period:false "?oobar") ".oobar");
+  let explicit_matching = `Slashes_and_leading_dots in
+  assert (re_mismatch (glob ~explicit_matching  "?oobar") ".oobar");
+  assert (re_mismatch (glob ~explicit_matching  "?oobar") "/oobar");
+  assert (re_mismatch (glob ~explicit_matching  "f?obar") "f/obar");
+  assert (re_match    (glob ~explicit_matching  "f?obar") "f.obar");
+  assert (re_match    (glob ~explicit_matching  "f*.bar") "f.bar");
+  assert (re_match    (glob ~explicit_matching  "f?.bar") "fo.bar");
+  assert (re_mismatch (glob ~explicit_matching  "*.bar")  ".bar");
+  assert (re_mismatch (glob ~explicit_matching  "?")      ".");
+
+  assert (re_mismatch (glob                     "?oobar") ".oobar");
+  assert (re_mismatch (glob                     "?oobar") "/oobar");
+
+  let explicit_matching = `Slashes in
+  assert (re_mismatch (glob ~explicit_matching  "?oobar") "/oobar");
+  assert (re_match    (glob ~explicit_matching  "?oobar") ".oobar");
+  assert (re_mismatch (glob ~explicit_matching  "f?obar") "f/obar");
+  assert (re_match    (glob ~explicit_matching  "f?obar") "f.obar");
+
+  let explicit_matching = `None in
+  assert (re_match    (glob ~explicit_matching  "?oobar") ".oobar");
+  assert (re_match    (glob ~explicit_matching  "?oobar") "/oobar");
 
   assert (re_match    (glob ~expand_braces:true "{foo,far}bar") "foobar"      );
   assert (re_match    (glob ~expand_braces:true "{foo,far}bar") "farbar"      );

--- a/lib_test/test_glob.ml
+++ b/lib_test/test_glob.ml
@@ -49,28 +49,33 @@ let _ =
   assert (re_match    (glob "{foo,bar}bar") "{foo,bar}bar");
   assert (re_mismatch (glob "foo?bar"     ) "foo/bar"     );
 
-  let explicit_matching = `Slashes_and_leading_dots in
-  assert (re_mismatch (glob ~explicit_matching  "?oobar") ".oobar");
-  assert (re_mismatch (glob ~explicit_matching  "?oobar") "/oobar");
-  assert (re_mismatch (glob ~explicit_matching  "f?obar") "f/obar");
-  assert (re_match    (glob ~explicit_matching  "f?obar") "f.obar");
-  assert (re_match    (glob ~explicit_matching  "f*.bar") "f.bar");
-  assert (re_match    (glob ~explicit_matching  "f?.bar") "fo.bar");
-  assert (re_mismatch (glob ~explicit_matching  "*.bar")  ".bar");
-  assert (re_mismatch (glob ~explicit_matching  "?")      ".");
+  let pathname = true in
+  let period = true in
+  assert (re_mismatch (glob ~pathname ~period  "?oobar") ".oobar");
+  assert (re_mismatch (glob ~pathname ~period  "?oobar") "/oobar");
+  assert (re_mismatch (glob ~pathname ~period  "f?obar") "f/obar");
+  assert (re_match    (glob ~pathname ~period  "f?obar") "f.obar");
+  assert (re_match    (glob ~pathname ~period  "f*.bar") "f.bar");
+  assert (re_match    (glob ~pathname ~period  "f?.bar") "fo.bar");
+  assert (re_match    (glob ~pathname ~period  "/.bar")  "/.bar");
+  assert (re_mismatch (glob ~pathname ~period  "*.bar")  ".bar");
+  assert (re_mismatch (glob ~pathname ~period  "?")      ".");
+  assert (re_mismatch (glob ~pathname ~period  "/*bar")  "/.bar");
 
   assert (re_mismatch (glob                     "?oobar") ".oobar");
   assert (re_mismatch (glob                     "?oobar") "/oobar");
 
-  let explicit_matching = `Slashes in
-  assert (re_mismatch (glob ~explicit_matching  "?oobar") "/oobar");
-  assert (re_match    (glob ~explicit_matching  "?oobar") ".oobar");
-  assert (re_mismatch (glob ~explicit_matching  "f?obar") "f/obar");
-  assert (re_match    (glob ~explicit_matching  "f?obar") "f.obar");
+  let pathname = true in
+  let period = false in
+  assert (re_mismatch (glob ~pathname ~period  "?oobar") "/oobar");
+  assert (re_match    (glob ~pathname ~period  "?oobar") ".oobar");
+  assert (re_mismatch (glob ~pathname ~period  "f?obar") "f/obar");
+  assert (re_match    (glob ~pathname ~period  "f?obar") "f.obar");
 
-  let explicit_matching = `None in
-  assert (re_match    (glob ~explicit_matching  "?oobar") ".oobar");
-  assert (re_match    (glob ~explicit_matching  "?oobar") "/oobar");
+  let pathname = false in
+  let period = false in
+  assert (re_match    (glob ~pathname ~period  "?oobar") ".oobar");
+  assert (re_match    (glob ~pathname ~period  "?oobar") "/oobar");
 
   assert (re_match    (glob ~expand_braces:true "{foo,far}bar") "foobar"      );
   assert (re_match    (glob ~expand_braces:true "{foo,far}bar") "farbar"      );

--- a/lib_test/test_glob.ml
+++ b/lib_test/test_glob.ml
@@ -32,6 +32,10 @@ let _ =
   assert (re_match    (glob ~anchored:true "*/foo") "/foo");
   assert (re_match    (glob ~anchored:true "foo/*") "foo/");
 
+  assert (re_mismatch (glob                "/[^f]") "/foo");
+  assert (re_match    (glob                "/[^f]") "/bar");
+  assert (re_mismatch (glob ~anchored:true "/[^f]") "/bar");
+
   assert (re_mismatch (glob ~anchored:true "*") ".bar");
 
   assert (re_match    (glob "foo[.]bar") "foo.bar");


### PR DESCRIPTION
Separate glob parsing from translation to the RE type.
Make the glob translation code a more obvious state machine.

This is a rewrite of all the glob code. The goal is to make the statefulness more explicit, make the parsing and translation phases distinct, and make the code more straightforward for new changes.