### PR TITLE
Fix last remaining warnings

### DIFF
--- a/lib_test/re_match.ml
+++ b/lib_test/re_match.ml
@@ -37,8 +37,8 @@ close_in ic;
 let check_phone cnt must_print line =
   try
     let matches = Re.exec rex line in
-    let num = String.copy "(...) ...-...."
-    and (pos, _) = Re.Group.offset matches 1 in
+    let num = "(...) ...-...." in
+    let (pos, _) = Re.Group.offset matches 1 in
     let ofs = if line.[pos] = '(' then 1 else 0 in
     let pos = pos + ofs in
     String.blit line pos num 1 3;

--- a/lib_test/test_str.ml
+++ b/lib_test/test_str.ml
@@ -7,7 +7,7 @@ let eq_match ?pos ?len ?(case = true) r s =
     (fun () ->
        let pos = match pos with None -> 0 | Some p -> p in
        let pat = if case then Str.regexp r else Str.regexp_case_fold r in
-       let s_start = Str.search_forward pat s pos in
+       let _s_start = Str.search_forward pat s pos in
 
        (* need a better way to determine group count -
           maybe parse the regular expression ? *)


### PR DESCRIPTION
* Remove seemingly pointless `String.copy`
* prefix unused variable with `_`
* Remove frivolous use of `and`. No need to use this without a recursive
  binding.