### PR TITLE
Bring back 4.00 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
 script: bash -ex .travis-opam.sh
 env:
+  - OCAML_VERSION=4.00
   - OCAML_VERSION=4.01
   - OCAML_VERSION=4.02
   - OCAML_VERSION=4.03

--- a/lib/re.ml
+++ b/lib/re.ml
@@ -1048,8 +1048,9 @@ module Group = struct
     let matches =
       let offsets = all_offset t in
       let strs = all t in
-      Array.init (Array.length strs) (fun i -> strs.(i), offsets.(i))
-      |> Array.to_list in
+      Array.to_list (
+        Array.init (Array.length strs) (fun i -> strs.(i), offsets.(i))
+      ) in
     let open Re_fmt in
     let pp_match fmt (str, (start, stop)) =
       fprintf fmt "@[(%s (%d %d))@]" str start stop in


### PR DESCRIPTION
By not using `(|>)`