### PR TITLE
exec{p,_partial} shouldn't initialize groups

### DIFF
--- a/lib/re.ml
+++ b/lib/re.ml
@@ -961,28 +961,28 @@ let no_case r = No_case r
 let compile r =
   compile_1 (if anchored r then group r else seq [shortest (rep any); group r])
 
-let exec_internal name ?(pos=0) ?(len = -1) re s =
+let exec_internal name ?(pos=0) ?(len = -1) ~groups re s =
   if pos < 0 || len < -1 || pos + len > String.length s then
     invalid_arg name;
-  match_str true false re s pos len
+  match_str groups false re s pos len
 
 let exec ?pos ?len re s =
-  match exec_internal "Re.exec" ?pos ?len re s with
+  match exec_internal "Re.exec" ?pos ?len ~groups:true re s with
     Match substr -> substr
   | _            -> raise Not_found
 
 let exec_opt ?pos ?len re s =
-  match exec_internal "Re.exec_opt" ?pos ?len re s with
+  match exec_internal "Re.exec_opt" ?pos ?len ~groups:true re s with
     Match substr -> Some substr
   | _            -> None
 
 let execp ?pos ?len re s =
-  match exec_internal "Re.execp" ?pos ?len re s with
+  match exec_internal ~groups:false "Re.execp" ?pos ?len re s with
     Match _substr -> true
   | _             -> false
 
 let exec_partial ?pos ?len re s =
-  match exec_internal "Re.exec_partial" ?pos ?len re s with
+  match exec_internal ~groups:false "Re.exec_partial" ?pos ?len re s with
     Match _ -> `Full
   | Running -> `Partial
   | Failed  -> `Mismatch


### PR DESCRIPTION
execp and exec_partial return either a flag or a boolean without any
group information. There's no need to initialize the group then.

Fix #105 

cc @Drup @sliquister @vouillon 