### PR TITLE
Use real laziness for Re_automata.state

### DIFF
--- a/lib/re.ml
+++ b/lib/re.ml
@@ -142,7 +142,7 @@ let unknown_state =
 
 let mk_state ncol desc =
   let break_state =
-    match Automata.status desc with
+    match Automata.State.status desc with
     | Automata.Running -> false
     | Automata.Failed
     | Automata.Match _ -> true
@@ -249,7 +249,7 @@ let final info st cat =
     List.assq cat st.final
   with Not_found ->
     let st' = delta info cat (-1) st in
-    let res = (st'.Automata.State.idx, Automata.status st') in
+    let res = (st'.Automata.State.idx, Automata.State.status st') in
     st.final <- (cat, res) :: st.final;
     res
 
@@ -334,7 +334,7 @@ let match_str ~groups ~partial re s ~pos ~len =
   let st = scan_str info s initial_state groups in
   let res =
     if st.idx = break || partial then
-      Automata.status st.desc
+      Automata.State.status st.desc
     else
       let final_cat =
         if last = slen then

--- a/lib/re_automata.mli
+++ b/lib/re_automata.mli
@@ -87,10 +87,11 @@ module State : sig
     { idx: idx
     ; category: category
     ; desc: E.t list
-    ; mutable status: status option
+    ; status: status Lazy.t
     ; hash: hash }
   val dummy : t
   val create : category -> expr -> t
+  val status : t -> status
   module Table : Hashtbl.S with type key = t
 end
 
@@ -106,7 +107,3 @@ val delta : working_area -> category -> Re_cset.c -> State.t -> State.t
 val deriv :
   working_area -> Re_cset.t -> (category * Re_cset.t) list -> State.t ->
   (Re_cset.t * State.t) list
-
-(****)
-
-val status : State.t -> status


### PR DESCRIPTION
Also, since it's just an accessor, it should rather be
Re_automata.State.t

The benchmarks results are the same except for 1 benchmark which is about %5
slower.