### PR TITLE
Remove unnecessary mutability

### DIFF
--- a/lib/re.ml
+++ b/lib/re.ml
@@ -80,7 +80,7 @@ type re =
         (* Number of colors *)
     lnl : int;
         (* Color of the last newline *)
-    mutable tbl : Automata.working_area;
+    tbl : Automata.working_area;
         (* Temporary table used to compute the first available index
            when computing a new state *)
     states : state Automata.State.Table.t;
@@ -102,9 +102,9 @@ type info =
     mutable positions : int array;
         (* Array of mark positions
            The mark are off by one for performance reasons *)
-    mutable pos : int;
+    pos : int;
         (* Position where the match is started *)
-    mutable last : int
+    last : int
         (* Position where the match should stop *) }
 
 
@@ -299,7 +299,7 @@ let rec scan_str info (s:string) initial_state groups =
     last > pos &&
     String.get s (last - 1) = '\n'
   then begin
-    info.last <- last - 1;
+    let info = { info with last = last - 1 } in
     let st = scan_str info s initial_state groups in
     if st.idx = break then
       st


### PR DESCRIPTION
tbl, pos, and last are all fields that are mutable but don't have to be.
Only last actually gets mutated, and we can easily replace it with a
functional update.

Benchmarks show this is just noise:

```
Name                             | Time(master) | Time(remove-mutability) | Delta   |
---------------------------------------------------------------------------------------
| 20 zeroes/exec/case 0            | 174.60ns     | 179.85ns | 3.01%   |
| 20 zeroes/execp/case 0           | 156.43ns     | 137.40ns | -12.17% |
| 20 zeroes/exec_opt/case 0        | 178.79ns     | 186.61ns | 4.37%   |
| lots of a's/exec/case 0          | 447.39ns     | 445.98ns | -0.32%  |
| lots of a's/execp/case 0         | 466.45ns     | 469.01ns | 0.55%   |
| lots of a's/exec_opt/case 0      | 447.45ns     | 444.33ns | -0.70%  |
| media type match/exec/case 0     | 88.51ns      | 87.89ns | -0.70%  |
| media type match/execp/case 0    | 63.55ns      | 63.50ns | -0.08%  |
| media type match/exec_opt/case 0 | 89.26ns      | 89.07ns | -0.21%  |
| uri/exec/case 0                  | 151.36ns     | 152.40ns | 0.69%   |
| uri/exec/case 1                  | 243.34ns     | 243.67ns | 0.14%   |
| uri/exec/case 2                  | 146.87ns     | 147.17ns | 0.20%   |
| uri/execp/case 0                 | 127.86ns     | 129.04ns | 0.92%   |
| uri/execp/case 1                 | 234.07ns     | 235.91ns | 0.79%   |
| uri/execp/case 2                 | 117.60ns     | 120.87ns | 2.78%   |
| uri/exec_opt/case 0              | 151.96ns     | 150.78ns | -0.78%  |
| uri/exec_opt/case 1              | 244.62ns     | 243.11ns | -0.62%  |
| uri/exec_opt/case 2              | 148.34ns     | 147.02ns | -0.89%  |
| tex gitignore/execp              | 225_029.77ns | 228_668.83ns | 1.62%   |
| tex gitignore/exec_opt           | 241_695.41ns | 237_768.14ns | -1.62%  |
| http/manual/no group             | 94_178.98ns  | 93_181.11ns | -1.06%  |
| http/manual/group                | 75_899.11ns  | 76_330.27ns | 0.57%   |
| http/auto/execp no group         | 112_052.08ns | 112_603.91ns | 0.49%   |
| http/auto/all_gen group          | 76_447.93ns  | 76_307.99ns | -0.18%  |
```