### PR TITLE
Implement Re.witness

### DIFF
--- a/lib/re.ml
+++ b/lib/re.ml
@@ -1221,7 +1221,41 @@ let replace ?(pos=0) ?len ?(all=true) re ~f s =
 let replace_string ?pos ?len ?all re ~by s =
   replace ?pos ?len ?all re s ~f:(fun _ -> by)
 
-
+let witness t =
+  let rec witness = function
+    | Set c -> String.make 1 (Char.chr (Cset.pick c))
+    | Sequence xs -> String.concat "" (List.map witness xs)
+    | Alternative (x :: _) -> witness x
+    | Alternative [] -> assert false
+    | Repeat (r, from, _to) ->
+      let w = witness r in
+      let b = Buffer.create (String.length w * from) in
+      for _i=1 to from do
+        Buffer.add_string b w
+      done;
+      Buffer.contents b
+    | No_case r -> witness r
+    | Intersection _
+    | Complement _
+    | Difference (_, _) -> assert false
+    | Group r
+    | No_group r
+    | Nest r
+    | Sem (_, r)
+    | Pmark (_, r)
+    | Case r
+    | Sem_greedy (_, r) -> witness r
+    | Beg_of_line
+    | End_of_line
+    | Beg_of_word
+    | End_of_word
+    | Not_bound
+    | Beg_of_str
+    | Last_end_of_line
+    | Start
+    | Stop
+    | End_of_str -> "" in
+  witness (handle_case false t)
 
 (** {2 Deprecated functions} *)
 

--- a/lib/re.mli
+++ b/lib/re.mli
@@ -371,6 +371,11 @@ val pp_re : Format.formatter -> re -> unit
 (** Alias for {!pp_re}. Deprecated *)
 val print_re : Format.formatter -> re -> unit
 
+(** {2 Experimental functions}. *)
+
+val witness : t -> string
+(** [witness r] generates a string [s] such that [execp (compile r) s] is
+    true *)
 
 (** {2 Deprecated functions} *)
 

--- a/lib/re_cset.ml
+++ b/lib/re_cset.ml
@@ -151,3 +151,7 @@ let rec prepend s x l =
       else ([d, c - 1], x') :: prepend s x (([c, d'], x') :: r')
     end
   | _ -> assert false
+
+let pick = function
+  | [] -> invalid_arg "Re_cset.pick"
+  | (x, _)::_ -> x

--- a/lib/re_cset.mli
+++ b/lib/re_cset.mli
@@ -59,3 +59,5 @@ val csingle : char -> t
 val is_empty : t -> bool
 
 val prepend : t -> 'a list -> (t * 'a list) list -> (t * 'a list) list
+
+val pick : t -> c

--- a/lib_test/test_re.ml
+++ b/lib_test/test_re.ml
@@ -1,4 +1,5 @@
 open Re
+open OUnit2
 open Fort_unit
 
 let re_match ?pos ?len r s res =
@@ -425,6 +426,16 @@ let _ =
     re_match (case (no_case (str "abc"))) "abc" [|(0,3)|];
     re_match (case (no_case (str "abc"))) "ABC" [|(0,3)|];
   );
+
+  expect_pass "witness" (fun () ->
+      let t r e = assert_equal ~printer:(fun x -> x) (witness r) e in
+
+      t (set "ac") "a";
+      t (repn (str "foo") 3 None) "foofoofoo";
+      t (alt [char 'c' ; char 'd']) "c";
+      t (no_case (str "test")) "TEST";
+      t eol ""
+    );
 
   (* Fixed bugs *)
 


### PR DESCRIPTION
`Re.witness re` is a function that generates a string s
such that `Re.execp (Re.compile re) s = true`

cc @Drup

This is really rough and dirty but I'm just hesitant of including
something like this in re. It seems like a completely useless
function for most users and hence just API bloat.