### PR TITLE
Fix Re_str.global_replace

### DIFF
--- a/lib/re_str.ml
+++ b/lib/re_str.ml
@@ -147,11 +147,11 @@ let rec replace orig repl p res q len =
           with Not_found ->
             0
         in
-        replace repl orig (p + 2) res (q + d) len
+        replace orig repl (p + 2) res (q + d) len
       | c ->
         Bytes.set res q '\\';
         Bytes.set res (q + 1) c;
-        replace repl orig (p + 2) res (q + 2) len
+        replace orig repl (p + 2) res (q + 2) len
     end
   end
 

--- a/lib_test/test_str.ml
+++ b/lib_test/test_str.ml
@@ -163,8 +163,11 @@ let _ =
     global_replace "needle" "" "needle";
     global_replace "xxx" "yyy" "zzz";
 
-    (* the test below fails *)
-    (* global_replace "\\(X+\\)" "A\\1YY" "XXXXXXZZZZ" *)
+    global_replace "test\\([0-9]*\\)" "\\1-foo-\\1" "test100 test200 test";
+    global_replace "test\\([0-9]*\\)" "'\\-0'" "test100 test200 test";
+
+    (* Regrssion test for #129 *)
+    global_replace "\\(X+\\)" "A\\1YY" "XXXXXXZZZZ"
   );
 
   expect_pass "split tests" (fun () ->


### PR DESCRIPTION
`orig` and `repl` arguments were accidentally switched for 2 recursive calls. Add regression tests for this issue.

Fix #129

cc @Drup