### PR TITLE
Update jbuilder rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ setup.exe
 *.native
 *.byte
 *.docdir
+.merlin
+*.install

--- a/benchmarks/jbuild
+++ b/benchmarks/jbuild
@@ -1,0 +1,4 @@
+(executables
+ ((libraries (re re.posix re.emacs re.glob threads core_bench))
+  (modules (benchmark))
+  (names (benchmark))))

--- a/jbuild
+++ b/jbuild
@@ -1,0 +1,1 @@
+(jbuild_version 1)

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -2,6 +2,8 @@
  ((name        re)
   (public_name re)
   (modules     (re re_fmt re_cset re_automata))
+  (wrapped     false)
+  (libraries   (bytes))
   (preprocess  no_preprocessing)))
 
 (library

--- a/lib_test/jbuild
+++ b/lib_test/jbuild
@@ -1,0 +1,65 @@
+(library
+ ((name        fort_unit)
+  (modules     (fort_unit))
+  (libraries   (re oUnit))
+  (preprocess  no_preprocessing)))
+
+(executables
+ ((libraries (re re.perl fort_unit))
+  (modules (test_re))
+  (names (test_re))))
+
+(executables
+ ((libraries (re re.perl fort_unit))
+  (modules (test_perl))
+  (names (test_perl))))
+
+(executables
+ ((libraries (re re.emacs fort_unit))
+  (modules (test_emacs))
+  (names (test_emacs))))
+
+(executables
+ ((libraries (re re.glob fort_unit))
+  (modules (test_glob))
+  (names (test_glob))))
+
+(executables
+ ((libraries (re re.str str fort_unit))
+  (modules (test_str))
+  (names (test_str))))
+
+(executables
+ ((libraries (re re.pcre pcre fort_unit))
+  (modules (test_pcre))
+  (names (test_pcre))))
+
+(alias
+ ((name   runtest)
+  (deps   (test_re.exe))
+  (action (run ${<}))))
+
+(alias
+ ((name   runtest)
+  (deps   (test_perl.exe))
+  (action (run ${<}))))
+
+(alias
+ ((name   runtest)
+  (deps   (test_emacs.exe))
+  (action (run ${<}))))
+
+(alias
+ ((name   runtest)
+  (deps   (test_glob.exe))
+  (action (run ${<}))))
+
+(alias
+ ((name   runtest)
+  (deps   (test_str.exe))
+  (action (run ${<}))))
+
+(alias
+ ((name   runtest)
+  (deps   (test_pcre.exe))
+  (action (run ${<}))))


### PR DESCRIPTION
* Set jbuild_version in a single file
* Update dependencies to include bytes
* Don't wrap Re module (for backwards compat.)
* Add build rules for tests
* Add build rules for benchmarks
* Update .gitignore to include .merlin and .install. These will be generated
by jbuilder