### PR TITLE
Remove dependency on bytes package

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -3,5 +3,4 @@
 (library
  ((name re)
   (synopsis "Pure OCaml regular expression library")
-  (public_name re)
-  (libraries (bytes))))
+  (public_name re)))

--- a/re.opam
+++ b/re.opam
@@ -21,7 +21,6 @@ build-test: [["jbuilder" "runtest" "-p" name "-j" jobs]]
 
 depends: [
   "jbuilder" {build}
-  "base-bytes"
   "ounit" {test}
 ]
 


### PR DESCRIPTION
Since ocaml-re now required OCaml 4.02.3 or later.

It's a slight nuisance for opam's vendored build, since by default it's built without `ocamlfind` present.