### PR TITLE
Two fixes for Re.Perl parser

### DIFF
--- a/lib/perl.ml
+++ b/lib/perl.ml
@@ -191,7 +191,7 @@ let parse multiline dollar_endonly dotall ungreedy s =
               `Char c' ->
               bracket (Re.rg c c' :: s)
             | `Set st' ->
-              Re.char c :: Re.char '-' :: st' :: s
+              bracket (Re.char c :: Re.char '-' :: st' :: s)
           end
         end else
           bracket (Re.char c :: s)

--- a/lib/perl.ml
+++ b/lib/perl.ml
@@ -246,6 +246,7 @@ let parse multiline dollar_endonly dotall ungreedy s =
     end else
       `Char c
   and comment () =
+    if eos () then raise Parse_error;
     if accept ')' then Re.epsilon else begin incr i; comment () end
   in
   let res = regexp () in

--- a/lib_test/test_perl.ml
+++ b/lib_test/test_perl.ml
@@ -126,6 +126,7 @@ let _ =
   expect_pass "comments" (fun () ->
     eq_re (seq [char 'a'; epsilon; char 'b'])
       "a(?#comment)b";
+    parse_error_re "(?#";
   );
 
   expect_pass "clustering" (fun () ->

--- a/lib_test/test_perl.ml
+++ b/lib_test/test_perl.ml
@@ -65,7 +65,10 @@ let _ =
     eq_re (alt [char '^'; char 'a'])      "[a^]";
     eq_re (compl [rg 'a' 'z'])            "[^a-z]";
     eq_re (compl [char '$'; rg 'a' 'z'])  "[^a-z$]";
+    eq_re (alt [char 'z'; char 'a'; char '-'; space])
+      "[a-\\sz]";
     parse_error_re                        "[\\";
+    parse_error_re                        "[a-\\s";
   );
 
   expect_pass "greedy quantifiers" (fun () ->


### PR DESCRIPTION
I found two more issues in the `Re.Perl` parser:
- `(?#` gave index out of bounds, changed to parse error.
- The backslash item in `[a-\sz]` terminated the `[` due to missing recursive call to `bracket`.