### PR TITLE
Expose view of regex type

### DIFF
--- a/lib/core.ml
+++ b/lib/core.ml
@@ -384,23 +384,23 @@ let trans_set cache cm s =
 
 (****)
 
-type t =
+type regexp =
     Set of Cset.t
-  | Sequence of t list
-  | Alternative of t list
-  | Repeat of t * int * int option
+  | Sequence of regexp list
+  | Alternative of regexp list
+  | Repeat of regexp * int * int option
   | Beg_of_line | End_of_line
   | Beg_of_word | End_of_word | Not_bound
   | Beg_of_str | End_of_str
   | Last_end_of_line | Start | Stop
-  | Sem of Automata.sem * t
-  | Sem_greedy of Automata.rep_kind * t
-  | Group of t | No_group of t | Nest of t
-  | Case of t | No_case of t
-  | Intersection of t list
-  | Complement of t list
-  | Difference of t * t
-  | Pmark of Pmark.t * t
+  | Sem of Automata.sem * regexp
+  | Sem_greedy of Automata.rep_kind * regexp
+  | Group of regexp | No_group of regexp | Nest of regexp
+  | Case of regexp | No_case of regexp
+  | Intersection of regexp list
+  | Complement of regexp list
+  | Difference of regexp * regexp
+  | Pmark of Pmark.t * regexp
 
 let rec pp fmt t =
   let open Fmt in
@@ -829,6 +829,8 @@ let rec anchored = function
     anchored r
 
 (****)
+
+type t = regexp
 
 let str s =
   let l = ref [] in

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -402,6 +402,8 @@ type regexp =
   | Difference of regexp * regexp
   | Pmark of Pmark.t * regexp
 
+let destruct t = t
+
 let rec pp fmt t =
   let open Fmt in
   let var s re = sexp fmt s pp re in

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -402,7 +402,27 @@ type regexp =
   | Difference of regexp * regexp
   | Pmark of Pmark.t * regexp
 
-let destruct t = t
+module View = struct
+  type t = regexp =
+      Set of Cset.t
+    | Sequence of regexp list
+    | Alternative of regexp list
+    | Repeat of regexp * int * int option
+    | Beg_of_line | End_of_line
+    | Beg_of_word | End_of_word | Not_bound
+    | Beg_of_str | End_of_str
+    | Last_end_of_line | Start | Stop
+    | Sem of Automata.sem * regexp
+    | Sem_greedy of Automata.rep_kind * regexp
+    | Group of regexp | No_group of regexp | Nest of regexp
+    | Case of regexp | No_case of regexp
+    | Intersection of regexp list
+    | Complement of regexp list
+    | Difference of regexp * regexp
+    | Pmark of Pmark.t * regexp
+
+  let view t = t
+end
 
 let rec pp fmt t =
   let open Fmt in

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -384,23 +384,23 @@ let trans_set cache cm s =
 
 (****)
 
-type regexp =
+type t =
     Set of Cset.t
-  | Sequence of regexp list
-  | Alternative of regexp list
-  | Repeat of regexp * int * int option
+  | Sequence of t list
+  | Alternative of t list
+  | Repeat of t * int * int option
   | Beg_of_line | End_of_line
   | Beg_of_word | End_of_word | Not_bound
   | Beg_of_str | End_of_str
   | Last_end_of_line | Start | Stop
-  | Sem of Automata.sem * regexp
-  | Sem_greedy of Automata.rep_kind * regexp
-  | Group of regexp | No_group of regexp | Nest of regexp
-  | Case of regexp | No_case of regexp
-  | Intersection of regexp list
-  | Complement of regexp list
-  | Difference of regexp * regexp
-  | Pmark of Pmark.t * regexp
+  | Sem of Automata.sem * t
+  | Sem_greedy of Automata.rep_kind * t
+  | Group of t | No_group of t | Nest of t
+  | Case of t | No_case of t
+  | Intersection of t list
+  | Complement of t list
+  | Difference of t * t
+  | Pmark of Pmark.t * t
 
 let rec pp fmt t =
   let open Fmt in
@@ -829,8 +829,6 @@ let rec anchored = function
     anchored r
 
 (****)
-
-type t = regexp
 
 let str s =
   let l = ref [] in

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -398,6 +398,27 @@ val pp_re : Format.formatter -> re -> unit
 (** Alias for {!pp_re}. Deprecated *)
 val print_re : Format.formatter -> re -> unit
 
+(** A view of the top-level of a regex. This type is unstable and may change *)
+type regexp =
+    Set of Ocaml_re_internal.Re_cset.t
+  | Sequence of t list
+  | Alternative of t list
+  | Repeat of t * int * int option
+  | Beg_of_line | End_of_line
+  | Beg_of_word | End_of_word | Not_bound
+  | Beg_of_str | End_of_str
+  | Last_end_of_line | Start | Stop
+  | Sem of Ocaml_re_internal.Re_automata.sem * t
+  | Sem_greedy of Ocaml_re_internal.Re_automata.rep_kind * t
+  | Group of t | No_group of t | Nest of t
+  | Case of t | No_case of t
+  | Intersection of t list
+  | Complement of t list
+  | Difference of t * t
+  | Pmark of Ocaml_re_internal.Re_automata.Pmark.t * t
+
+val destruct : t -> regexp
+
 (** {2 Experimental functions}. *)
 
 val witness : t -> string

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -22,23 +22,7 @@
 
 (** Module [Re]: regular expressions commons *)
 
-type t = private
-    Set of Cset.t
-  | Sequence of t list
-  | Alternative of t list
-  | Repeat of t * int * int option
-  | Beg_of_line | End_of_line
-  | Beg_of_word | End_of_word | Not_bound
-  | Beg_of_str | End_of_str
-  | Last_end_of_line | Start | Stop
-  | Sem of Automata.sem * t
-  | Sem_greedy of Automata.rep_kind * t
-  | Group of t | No_group of t | Nest of t
-  | Case of t | No_case of t
-  | Intersection of t list
-  | Complement of t list
-  | Difference of t * t
-  | Pmark of Pmark.t * t
+type t
 (** Regular expression *)
 
 type re

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -22,7 +22,23 @@
 
 (** Module [Re]: regular expressions commons *)
 
-type t
+type t = private
+    Set of Cset.t
+  | Sequence of t list
+  | Alternative of t list
+  | Repeat of t * int * int option
+  | Beg_of_line | End_of_line
+  | Beg_of_word | End_of_word | Not_bound
+  | Beg_of_str | End_of_str
+  | Last_end_of_line | Start | Stop
+  | Sem of Automata.sem * t
+  | Sem_greedy of Automata.rep_kind * t
+  | Group of t | No_group of t | Nest of t
+  | Case of t | No_case of t
+  | Intersection of t list
+  | Complement of t list
+  | Difference of t * t
+  | Pmark of Pmark.t * t
 (** Regular expression *)
 
 type re

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -398,26 +398,30 @@ val pp_re : Format.formatter -> re -> unit
 (** Alias for {!pp_re}. Deprecated *)
 val print_re : Format.formatter -> re -> unit
 
-(** A view of the top-level of a regex. This type is unstable and may change *)
-type regexp =
-    Set of Ocaml_re_internal.Re_cset.t
-  | Sequence of t list
-  | Alternative of t list
-  | Repeat of t * int * int option
-  | Beg_of_line | End_of_line
-  | Beg_of_word | End_of_word | Not_bound
-  | Beg_of_str | End_of_str
-  | Last_end_of_line | Start | Stop
-  | Sem of Ocaml_re_internal.Re_automata.sem * t
-  | Sem_greedy of Ocaml_re_internal.Re_automata.rep_kind * t
-  | Group of t | No_group of t | Nest of t
-  | Case of t | No_case of t
-  | Intersection of t list
-  | Complement of t list
-  | Difference of t * t
-  | Pmark of Ocaml_re_internal.Re_automata.Pmark.t * t
+module View : sig
+  type outer
 
-val destruct : t -> regexp
+  (** A view of the top-level of a regex. This type is unstable and may change *)
+  type t =
+      Set of Cset.t
+    | Sequence of outer list
+    | Alternative of outer list
+    | Repeat of outer * int * int option
+    | Beg_of_line | End_of_line
+    | Beg_of_word | End_of_word | Not_bound
+    | Beg_of_str | End_of_str
+    | Last_end_of_line | Start | Stop
+    | Sem of Automata.sem * outer
+    | Sem_greedy of Automata.rep_kind * outer
+    | Group of outer | No_group of outer | Nest of outer
+    | Case of outer | No_case of outer
+    | Intersection of outer list
+    | Complement of outer list
+    | Difference of outer * outer
+    | Pmark of Pmark.t * outer
+
+  val view : outer -> t
+end with type outer := t
 
 (** {2 Experimental functions}. *)
 


### PR DESCRIPTION
Exposes the variant type [t] for pattern matching by downstream users, without allowing unchecked construction.