### PR TITLE
Some cleanup + More consistent naming

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,11 @@
-1.8.0 (04-Aug-2018)
+1.8.0 (13-Feb-2019)
 -------------------
 
+* Fix regression in `Re.exec_partial` (#164)
 * Fix index-out-of-bounds exception in Re.Perl.re (#160)
 * Add seq based iterators (#170)
+* Mov gen related functions to `Re.Gen` and deprecate the old names (#167)
+* Introduce `Re.View` that exposes the internal representation (#163)
 
 1.7.3 (05-Mar-2018)
 -------------------

--- a/lib/color_map.ml
+++ b/lib/color_map.ml
@@ -1,20 +1,32 @@
+(* In reality, this can really be represented as a bool array.
+
+   The representation is best thought of as a list of all chars along with a
+   flag:
+
+   (a, 0), (b, 1), (c, 0), (d, 0), ...
+
+   characters belonging to the same color are represented by sequnces of
+   characters with the flag set to 0.
+*)
+
 type t = Bytes.t
 
 let make () = Bytes.make 257 '\000'
 
 let flatten cm =
   let c = Bytes.create 256 in
-  let col_repr = Bytes.create 256 in
+  let color_repr = Bytes.create 256 in
   let v = ref 0 in
   Bytes.set c 0 '\000';
-  Bytes.set col_repr 0 '\000';
+  Bytes.set color_repr 0 '\000';
   for i = 1 to 255 do
     if Bytes.get cm i <> '\000' then incr v;
     Bytes.set c i (Char.chr !v);
-    Bytes.set col_repr !v (Char.chr i)
+    Bytes.set color_repr !v (Char.chr i)
   done;
-  (c, Bytes.sub col_repr 0 (!v + 1), !v + 1)
+  (c, Bytes.sub color_repr 0 (!v + 1), !v + 1)
 
+(* mark all the endpoints of the intervals of the char set with the 1 byte *)
 let split s cm =
   Cset.iter s ~f:(fun i j ->
       Bytes.set cm i '\001';

--- a/lib/color_map.ml
+++ b/lib/color_map.ml
@@ -1,0 +1,22 @@
+type t = Bytes.t
+
+let make () = Bytes.make 257 '\000'
+
+let flatten cm =
+  let c = Bytes.create 256 in
+  let col_repr = Bytes.create 256 in
+  let v = ref 0 in
+  Bytes.set c 0 '\000';
+  Bytes.set col_repr 0 '\000';
+  for i = 1 to 255 do
+    if Bytes.get cm i <> '\000' then incr v;
+    Bytes.set c i (Char.chr !v);
+    Bytes.set col_repr !v (Char.chr i)
+  done;
+  (c, Bytes.sub col_repr 0 (!v + 1), !v + 1)
+
+let split s cm =
+  Cset.iter s ~f:(fun i j ->
+      Bytes.set cm i '\001';
+      Bytes.set cm (j + 1) '\001';
+    )

--- a/lib/color_map.mli
+++ b/lib/color_map.mli
@@ -1,0 +1,7 @@
+type t
+
+val make : unit -> t
+
+val flatten : t -> bytes * bytes * int
+
+val split : Cset.t -> t -> unit

--- a/lib/color_map.mli
+++ b/lib/color_map.mli
@@ -1,3 +1,10 @@
+(* Color maps exists to provide an optimization for the regex engine. The fact
+   that some characters are entirely equivalent for some regexes means that we
+   can use them interchangeably.
+
+   A color map assigns a color to every character in our character set. Any two
+   characters with the same color will be treated equivalently by the automaton.
+*)
 type t
 
 val make : unit -> t

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -1184,13 +1184,9 @@ module Group = Group
 (** {2 Deprecated functions} *)
 
 type 'a gen        = 'a Gen.gen
-let all            = List.all
 let all_gen        = Gen.all
-let matches        = List.matches
 let matches_gen    = Gen.matches
-let split          = List.split
 let split_gen      = Gen.split
-let split_full     = List.split_full
 let split_full_gen = Gen.split_full
 
 
@@ -1248,3 +1244,5 @@ Bounded repetition
 *)
 
 type groups = Group.t
+
+include Rlist

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -971,121 +971,133 @@ module Mark = struct
 
 end
 
-type 'a gen = unit -> 'a option
-
-let gen_of_seq (s:'a Seq.t) : 'a gen =
-  let r = ref s in
-  fun () -> match !r () with
-    | Seq.Nil -> None
-    | Seq.Cons (x, tl) ->
-      r := tl;
-      Some x
-
-let list_of_seq (s:'a Seq.t) : 'a list =
-  Seq.fold_left (fun l x -> x :: l) [] s |> List.rev
-
-let all_seq ?(pos=0) ?len re s : _ Seq.t =
-  if pos < 0 then invalid_arg "Re.all";
-  (* index of the first position we do not consider.
-     !pos < limit is an invariant *)
-  let limit = match len with
-    | None -> String.length s
-    | Some l ->
-      if l<0 || pos+l > String.length s then invalid_arg "Re.all";
-      pos+l
-  in
-  (* iterate on matches. When a match is found, search for the next
-     one just after its end *)
-  let rec aux pos () =
-    if pos >= limit
-    then Seq.Nil (* no more matches *)
-    else
-      match match_str ~groups:true ~partial:false re s
-              ~pos ~len:(limit - pos) with
-      | Match substr ->
-        let p1, p2 = Group.offset substr 0 in
-        let pos = if p1=p2 then p2+1 else p2 in
-        Seq.Cons (substr, aux pos)
-      | Running
-      | Failed -> Seq.Nil
-  in
-  aux pos
-
-let all_gen ?pos ?len re s = all_seq ?pos ?len re s |> gen_of_seq
-let all ?pos ?len re s = all_seq ?pos ?len re s |> list_of_seq
-
-let matches_seq ?pos ?len re s : _ Seq.t =
-  all_seq ?pos ?len re s
-  |> Seq.map (fun sub -> Group.get sub 0)
-
-let matches_gen ?pos ?len re s = matches_seq ?pos ?len re s |> gen_of_seq
-let matches ?pos ?len re s = matches_seq ?pos ?len re s |> list_of_seq
-
 type split_token =
   [ `Text of string
   | `Delim of Group.t
   ]
 
-let split_full_seq ?(pos=0) ?len re s : _ Seq.t =
-  if pos < 0 then invalid_arg "Re.split";
-  let limit = match len with
-    | None -> String.length s
-    | Some l ->
-      if l<0 || pos+l > String.length s then invalid_arg "Re.split";
-      pos+l
-  in
-  (* i: start of delimited string
-     pos: first position after last match of [re]
-     limit: first index we ignore (!pos < limit is an invariant) *)
-  let pos0 = pos in
-  let rec aux state i pos () = match state with
-    | `Idle when pos >= limit ->
-      if i < limit then (
-        let sub = String.sub s i (limit - i) in
-        Seq.Cons (`Text sub, aux state (i+1) pos)
-      ) else Seq.Nil
-    | `Idle ->
-      begin match match_str ~groups:true ~partial:false re s ~pos
-                    ~len:(limit - pos) with
-      | Match substr ->
-        let p1, p2 = Group.offset substr 0 in
-        let pos = if p1=p2 then p2+1 else p2 in
-        let old_i = i in
-        let i = p2 in
-        if p1 > pos0 then (
-          (* string does not start by a delimiter *)
-          let text = String.sub s old_i (p1 - old_i) in
-          let state = `Yield (`Delim substr) in
-          Seq.Cons (`Text text, aux state i pos)
-        ) else Seq.Cons (`Delim substr, aux state i pos)
-      | Running -> Seq.Nil
-      | Failed ->
-        if i < limit
-        then (
-          let text = String.sub s i (limit - i) in
-          (* yield last string *)
-          Seq.Cons (`Text text, aux state limit pos)
-        ) else
-          Seq.Nil
-      end
-    | `Yield x ->
-      Seq.Cons (x, aux `Idle i pos)
-  in
-  aux `Idle pos pos
+module Rseq = struct
+  let all ?(pos=0) ?len re s : _ Seq.t =
+    if pos < 0 then invalid_arg "Re.all";
+    (* index of the first position we do not consider.
+       !pos < limit is an invariant *)
+    let limit = match len with
+      | None -> String.length s
+      | Some l ->
+        if l<0 || pos+l > String.length s then invalid_arg "Re.all";
+        pos+l
+    in
+    (* iterate on matches. When a match is found, search for the next
+       one just after its end *)
+    let rec aux pos () =
+      if pos >= limit
+      then Seq.Nil (* no more matches *)
+      else
+        match match_str ~groups:true ~partial:false re s
+                ~pos ~len:(limit - pos) with
+        | Match substr ->
+          let p1, p2 = Group.offset substr 0 in
+          let pos = if p1=p2 then p2+1 else p2 in
+          Seq.Cons (substr, aux pos)
+        | Running
+        | Failed -> Seq.Nil
+    in
+    aux pos
 
-let split_full_gen ?pos ?len re s : _ gen = split_full_seq ?pos ?len re s |> gen_of_seq
-let split_full ?pos ?len re s = split_full_seq ?pos ?len re s |> list_of_seq
+  let matches ?pos ?len re s : _ Seq.t =
+    all ?pos ?len re s
+    |> Seq.map (fun sub -> Group.get sub 0)
 
-let split_seq ?pos ?len re s : _ Seq.t =
-  let seq = split_full_seq ?pos ?len re s in
-  let rec filter seq () = match seq ()  with
-    | Seq.Nil -> Seq.Nil
-    | Seq.Cons (`Delim _, tl) -> filter tl ()
-    | Seq.Cons (`Text s,tl) -> Seq.Cons (s, filter tl)
-  in filter seq
+  let split_full ?(pos=0) ?len re s : _ Seq.t =
+    if pos < 0 then invalid_arg "Re.split";
+    let limit = match len with
+      | None -> String.length s
+      | Some l ->
+        if l<0 || pos+l > String.length s then invalid_arg "Re.split";
+        pos+l
+    in
+    (* i: start of delimited string
+       pos: first position after last match of [re]
+       limit: first index we ignore (!pos < limit is an invariant) *)
+    let pos0 = pos in
+    let rec aux state i pos () = match state with
+      | `Idle when pos >= limit ->
+        if i < limit then (
+          let sub = String.sub s i (limit - i) in
+          Seq.Cons (`Text sub, aux state (i+1) pos)
+        ) else Seq.Nil
+      | `Idle ->
+        begin match match_str ~groups:true ~partial:false re s ~pos
+                      ~len:(limit - pos) with
+        | Match substr ->
+          let p1, p2 = Group.offset substr 0 in
+          let pos = if p1=p2 then p2+1 else p2 in
+          let old_i = i in
+          let i = p2 in
+          if p1 > pos0 then (
+            (* string does not start by a delimiter *)
+            let text = String.sub s old_i (p1 - old_i) in
+            let state = `Yield (`Delim substr) in
+            Seq.Cons (`Text text, aux state i pos)
+          ) else Seq.Cons (`Delim substr, aux state i pos)
+        | Running -> Seq.Nil
+        | Failed ->
+          if i < limit
+          then (
+            let text = String.sub s i (limit - i) in
+            (* yield last string *)
+            Seq.Cons (`Text text, aux state limit pos)
+          ) else
+            Seq.Nil
+        end
+      | `Yield x ->
+        Seq.Cons (x, aux `Idle i pos)
+    in
+    aux `Idle pos pos
 
-let split_gen ?pos ?len re s : _ gen = split_seq ?pos ?len re s |> gen_of_seq
-let split ?pos ?len re s = split_seq ?pos ?len re s |> list_of_seq
+  let split ?pos ?len re s : _ Seq.t =
+    let seq = split_full ?pos ?len re s in
+    let rec filter seq () = match seq ()  with
+      | Seq.Nil -> Seq.Nil
+      | Seq.Cons (`Delim _, tl) -> filter tl ()
+      | Seq.Cons (`Text s,tl) -> Seq.Cons (s, filter tl)
+    in filter seq
+end
+
+module L = struct
+
+  let list_of_seq (s:'a Seq.t) : 'a list =
+    Seq.fold_left (fun l x -> x :: l) [] s |> List.rev
+
+  let all ?pos ?len re s = Rseq.all ?pos ?len re s |> list_of_seq
+
+  let matches ?pos ?len re s = Rseq.matches ?pos ?len re s |> list_of_seq
+
+  let split_full ?pos ?len re s = Rseq.split_full ?pos ?len re s |> list_of_seq
+
+  let split ?pos ?len re s = Rseq.split ?pos ?len re s |> list_of_seq
+end
+
+module Gen = struct
+  type 'a gen = unit -> 'a option
+  let gen_of_seq (s:'a Seq.t) : 'a gen =
+    let r = ref s in
+    fun () -> match !r () with
+      | Seq.Nil -> None
+      | Seq.Cons (x, tl) ->
+        r := tl;
+        Some x
+
+  let split ?pos ?len re s : _ gen =
+    Rseq.split ?pos ?len re s |> gen_of_seq
+
+  let split_full ?pos ?len re s : _ gen =
+    Rseq.split_full ?pos ?len re s |> gen_of_seq
+
+  let all ?pos ?len re s = Rseq.all ?pos ?len re s |> gen_of_seq
+
+  let matches ?pos ?len re s = Rseq.matches ?pos ?len re s |> gen_of_seq
+end
 
 let replace ?(pos=0) ?len ?(all=true) re ~f s =
   if pos < 0 then invalid_arg "Re.replace";
@@ -1166,7 +1178,20 @@ let witness t =
     | End_of_str -> "" in
   witness (handle_case false t)
 
+module Seq = Rseq
+module Group = Group
+
 (** {2 Deprecated functions} *)
+
+let all            = L.all
+let all_gen        = Gen.all
+let matches        = L.matches
+let matches_gen    = Gen.matches
+let split          = L.split
+let split_gen      = Gen.split
+let split_full     = L.split_full
+let split_full_gen = Gen.split_full
+
 
 type substrings = Group.t
 
@@ -1221,5 +1246,4 @@ Bounded repetition
   a{0,3} = (a,(a,a?)?)?
 *)
 
-module Group = Group
 type groups = Group.t

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -1064,8 +1064,7 @@ module Rseq = struct
     in filter seq
 end
 
-module L = struct
-
+module List = struct
   let list_of_seq (s:'a Seq.t) : 'a list =
     Seq.fold_left (fun l x -> x :: l) [] s |> List.rev
 

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -120,14 +120,14 @@ type info =
 
 (****)
 
-let category re c =
-  if c = -1 then
+let category re color =
+  if color = -1 then
     Category.inexistant
     (* Special category for the last newline *)
-  else if c = re.lnl then
+  else if color = re.lnl then
     Category.(lastnewline ++ newline ++ not_letter)
   else
-    Category.from_char (Bytes.get re.color_repr c)
+    Category.from_char (Bytes.get re.color_repr color)
 
 (****)
 

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -1064,7 +1064,7 @@ module Rseq = struct
     in filter seq
 end
 
-module List = struct
+module Rlist = struct
   let list_of_seq (s:'a Seq.t) : 'a list =
     Seq.fold_left (fun l x -> x :: l) [] s |> List.rev
 
@@ -1178,17 +1178,19 @@ let witness t =
   witness (handle_case false t)
 
 module Seq = Rseq
+module List = Rlist
 module Group = Group
 
 (** {2 Deprecated functions} *)
 
-let all            = L.all
+type 'a gen        = 'a Gen.gen
+let all            = List.all
 let all_gen        = Gen.all
-let matches        = L.matches
+let matches        = List.matches
 let matches_gen    = Gen.matches
-let split          = L.split
+let split          = List.split
 let split_gen      = Gen.split
-let split_full     = L.split_full
+let split_full     = List.split_full
 let split_full_gen = Gen.split_full
 
 

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -120,88 +120,117 @@ end
 
 (** {2 High Level Operations} *)
 
-type 'a gen = unit -> 'a option
-
-val all :
-  ?pos:int ->    (** Default: 0 *)
-  ?len:int ->
-  re -> string -> Group.t list
-(** Repeatedly calls {!exec} on the given string, starting at given
-    position and length.*)
-
-val all_gen :
-  ?pos:int ->    (** Default: 0 *)
-  ?len:int ->
-  re -> string -> Group.t gen
-(** Same as {!all} but returns a generator *)
-
-val all_seq :
-  ?pos:int ->    (** Default: 0 *)
-  ?len:int ->
-  re -> string -> Group.t Seq.t
-(** Same as {!all} but returns an iterator
-    @since NEXT_RELEASE *)
-
-val matches :
-  ?pos:int ->    (** Default: 0 *)
-  ?len:int ->
-  re -> string -> string list
-(** Same as {!all}, but extracts the matched substring rather than
-    returning the whole group. This basically iterates over matched
-    strings *)
-
-val matches_gen :
-  ?pos:int ->    (** Default: 0 *)
-  ?len:int ->
-  re -> string -> string gen
-(** Same as {!matches}, but returns a generator. *)
-
-val matches_seq :
-  ?pos:int ->    (** Default: 0 *)
-  ?len:int ->
-  re -> string -> string Seq.t
-(** Same as {!matches}, but returns an iterator
-    @since NEXT_RELEASE *)
-
-val split :
-  ?pos:int ->    (** Default: 0 *)
-  ?len:int ->
-  re -> string -> string list
-(** [split re s] splits [s] into chunks separated by [re]. It yields
-    the chunks themselves, not the separator. For instance
-    this can be used with a whitespace-matching re such as ["[\t ]+"]. *)
-
-val split_gen :
-  ?pos:int ->    (** Default: 0 *)
-  ?len:int ->
-  re -> string -> string gen
-
-val split_seq :
-  ?pos:int ->    (** Default: 0 *)
-  ?len:int ->
-  re -> string -> string Seq.t
-(** @since NEXT_RELEASE *)
-
 type split_token =
   [ `Text of string  (** Text between delimiters *)
   | `Delim of Group.t (** Delimiter *)
   ]
 
-val split_full :
-  ?pos:int ->    (** Default: 0 *)
-  ?len:int ->
-  re -> string -> split_token list
+module Seq : sig
+  val all :
+    ?pos:int ->    (** Default: 0 *)
+    ?len:int ->
+    re -> string -> Group.t Seq.t
+    (** Same as {!all} but returns an iterator
+        @since NEXT_RELEASE *)
 
-val split_full_gen :
-  ?pos:int ->    (** Default: 0 *)
-  ?len:int ->
-  re -> string -> split_token gen
+  val matches :
+    ?pos:int ->    (** Default: 0 *)
+    ?len:int ->
+    re -> string -> string Seq.t
+    (** Same as {!matches}, but returns an iterator
+        @since NEXT_RELEASE *)
 
-val split_full_seq :
-  ?pos:int ->    (** Default: 0 *)
-  ?len:int ->
-  re -> string -> split_token Seq.t
-(** @since NEXT_RELEASE *)
+  val split :
+    ?pos:int ->    (** Default: 0 *)
+    ?len:int ->
+    re -> string -> string Seq.t
+    (** @since NEXT_RELEASE *)
+
+  val split_full :
+    ?pos:int ->    (** Default: 0 *)
+    ?len:int ->
+    re -> string -> split_token Seq.t
+    (** @since NEXT_RELEASE *)
+end
+
+module L : sig
+  val all :
+    ?pos:int ->    (** Default: 0 *)
+    ?len:int ->
+    re -> string -> Group.t list
+  (** Repeatedly calls {!exec} on the given string, starting at given position
+      and length.*)
+
+  val matches :
+    ?pos:int ->    (** Default: 0 *)
+    ?len:int ->
+    re -> string -> string list
+  (** Same as {!all}, but extracts the matched substring rather than returning
+      the whole group. This basically iterates over matched strings *)
+
+  val split :
+    ?pos:int ->    (** Default: 0 *)
+    ?len:int ->
+    re -> string -> string list
+  (** [split re s] splits [s] into chunks separated by [re]. It yields the
+      chunks themselves, not the separator. For instance this can be used with a
+      whitespace-matching re such as ["[\t ]+"]. *)
+
+  val split_full :
+    ?pos:int ->    (** Default: 0 *)
+    ?len:int ->
+    re -> string -> split_token list
+end
+
+module Gen : sig
+  type 'a gen = unit -> 'a option
+
+  val all :
+    ?pos:int ->    (** Default: 0 *)
+    ?len:int ->
+    re -> string -> Group.t gen
+  (** Same as {!all} but returns a generator *)
+
+  val matches :
+    ?pos:int ->    (** Default: 0 *)
+    ?len:int ->
+    re -> string -> string gen
+  (** Same as {!matches}, but returns a generator. *)
+
+  val split :
+    ?pos:int ->    (** Default: 0 *)
+    ?len:int ->
+    re -> string -> string gen
+
+  val split_full :
+    ?pos:int ->    (** Default: 0 *)
+    ?len:int ->
+    re -> string -> split_token gen
+end
+
+val all : ?pos:int -> ?len:int -> re -> string -> Group.t list
+[@@ocaml.deprecated "Use L.all"]
+
+val all_gen : ?pos:int -> ?len:int -> re -> string -> Group.t Gen.gen
+[@@ocaml.deprecated "Use Gen.all"]
+
+val matches : ?pos:int -> ?len:int -> re -> string -> string list
+[@@ocaml.deprecated "Use L.matches"]
+
+val matches_gen : ?pos:int -> ?len:int -> re -> string -> string Gen.gen
+[@@ocaml.deprecated "Use Gen.matches"]
+
+val split : ?pos:int -> ?len:int -> re -> string -> string list
+[@@ocaml.deprecated "Use L.split"]
+
+val split_gen : ?pos:int -> ?len:int -> re -> string -> string Gen.gen
+[@@ocaml.deprecated "Use Gen.split"]
+
+val split_full : ?pos:int -> ?len:int -> re -> string -> split_token list
+[@@ocaml.deprecated "Use L.split_full"]
+
+val split_full_gen : ?pos:int -> ?len:int -> re -> string -> split_token Gen.gen
+[@@ocaml.deprecated "Use Gen.split_full"]
 
 val replace :
   ?pos:int ->    (** Default: 0 *)

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -60,7 +60,7 @@ module Group : sig
 
   val pp : Format.formatter -> t -> unit
 end
-type groups = Group.t
+type groups = Group.t [@@ocaml.deprecated "Use Group.t"]
 
 (** {2 Compilation and execution of a regular expression} *)
 
@@ -430,26 +430,34 @@ val witness : t -> string
 type substrings = Group.t
 (** Alias for {!Group.t}. Deprecated *)
 
+[@@ocaml.deprecated "Use Group.get"]
 val get : Group.t -> int -> string
 (** Same as {!Group.get}. Deprecated *)
 
+[@@ocaml.deprecated "Use Group.offset"]
 val get_ofs : Group.t -> int -> int * int
 (** Same as {!Group.offset}. Deprecated *)
 
+[@@ocaml.deprecated "Use Group.all"]
 val get_all : Group.t -> string array
 (** Same as {!Group.all}. Deprecated *)
 
+[@@ocaml.deprecated "Use Group.all_offset"]
 val get_all_ofs : Group.t -> (int * int) array
 (** Same as {!Group.all_offset}. Deprecated *)
 
+[@@ocaml.deprecated "Use Group.test"]
 val test : Group.t -> int -> bool
 (** Same as {!Group.test}. Deprecated *)
 
+[@@ocaml.deprecated "Use Mark."]
 type markid = Mark.t
 (** Alias for {!Mark.t}. Deprecated *)
 
+[@@ocaml.deprecated "Use Mark.test"]
 val marked : Group.t -> Mark.t -> bool
 (** Same as {!Mark.test}. Deprecated *)
 
+[@@ocaml.deprecated "Use Mark.all"]
 val mark_set : Group.t -> Mark.Set.t
 (** Same as {!Mark.all}. Deprecated *)

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -153,7 +153,7 @@ module Seq : sig
     (** @since NEXT_RELEASE *)
 end
 
-module L : sig
+module List : sig
   val all :
     ?pos:int ->    (** Default: 0 *)
     ?len:int ->

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -182,55 +182,31 @@ module List : sig
     re -> string -> split_token list
 end
 
-module Gen : sig
-  type 'a gen = unit -> 'a option
-
-  val all :
-    ?pos:int ->    (** Default: 0 *)
-    ?len:int ->
-    re -> string -> Group.t gen
-  (** Same as {!all} but returns a generator *)
-
-  val matches :
-    ?pos:int ->    (** Default: 0 *)
-    ?len:int ->
-    re -> string -> string gen
-  (** Same as {!matches}, but returns a generator. *)
-
-  val split :
-    ?pos:int ->    (** Default: 0 *)
-    ?len:int ->
-    re -> string -> string gen
-
-  val split_full :
-    ?pos:int ->    (** Default: 0 *)
-    ?len:int ->
-    re -> string -> split_token gen
-end
-
 val all : ?pos:int -> ?len:int -> re -> string -> Group.t list
-[@@ocaml.deprecated "Use L.all"]
+[@@ocaml.deprecated "Use List.all"]
 
-val all_gen : ?pos:int -> ?len:int -> re -> string -> Group.t Gen.gen
-[@@ocaml.deprecated "Use Gen.all"]
+type 'a gen = unit -> 'a option
+
+val all_gen : ?pos:int -> ?len:int -> re -> string -> Group.t gen
+[@@ocaml.deprecated "Use Seq.all"]
 
 val matches : ?pos:int -> ?len:int -> re -> string -> string list
-[@@ocaml.deprecated "Use L.matches"]
+[@@ocaml.deprecated "Use List.matches"]
 
-val matches_gen : ?pos:int -> ?len:int -> re -> string -> string Gen.gen
-[@@ocaml.deprecated "Use Gen.matches"]
+val matches_gen : ?pos:int -> ?len:int -> re -> string -> string gen
+[@@ocaml.deprecated "Use Seq.matches"]
 
 val split : ?pos:int -> ?len:int -> re -> string -> string list
-[@@ocaml.deprecated "Use L.split"]
+[@@ocaml.deprecated "Use List.split"]
 
-val split_gen : ?pos:int -> ?len:int -> re -> string -> string Gen.gen
-[@@ocaml.deprecated "Use Gen.split"]
+val split_gen : ?pos:int -> ?len:int -> re -> string -> string gen
+[@@ocaml.deprecated "Use Seq.split"]
 
 val split_full : ?pos:int -> ?len:int -> re -> string -> split_token list
-[@@ocaml.deprecated "Use L.split_full"]
+[@@ocaml.deprecated "Use List.split_full"]
 
-val split_full_gen : ?pos:int -> ?len:int -> re -> string -> split_token Gen.gen
-[@@ocaml.deprecated "Use Gen.split_full"]
+val split_full_gen : ?pos:int -> ?len:int -> re -> string -> split_token gen
+[@@ocaml.deprecated "Use Seq.split_full"]
 
 val replace :
   ?pos:int ->    (** Default: 0 *)
@@ -457,36 +433,37 @@ val witness : t -> string
 (** {2 Deprecated functions} *)
 
 type substrings = Group.t
+[@@ocaml.deprecated "Use Group.t"]
 (** Alias for {!Group.t}. Deprecated *)
 
-[@@ocaml.deprecated "Use Group.get"]
 val get : Group.t -> int -> string
+[@@ocaml.deprecated "Use Group.get"]
 (** Same as {!Group.get}. Deprecated *)
 
-[@@ocaml.deprecated "Use Group.offset"]
 val get_ofs : Group.t -> int -> int * int
+[@@ocaml.deprecated "Use Group.offset"]
 (** Same as {!Group.offset}. Deprecated *)
 
-[@@ocaml.deprecated "Use Group.all"]
 val get_all : Group.t -> string array
+[@@ocaml.deprecated "Use Group.all"]
 (** Same as {!Group.all}. Deprecated *)
 
-[@@ocaml.deprecated "Use Group.all_offset"]
 val get_all_ofs : Group.t -> (int * int) array
+[@@ocaml.deprecated "Use Group.all_offset"]
 (** Same as {!Group.all_offset}. Deprecated *)
 
-[@@ocaml.deprecated "Use Group.test"]
 val test : Group.t -> int -> bool
+[@@ocaml.deprecated "Use Group.test"]
 (** Same as {!Group.test}. Deprecated *)
 
-[@@ocaml.deprecated "Use Mark."]
 type markid = Mark.t
+[@@ocaml.deprecated "Use Mark."]
 (** Alias for {!Mark.t}. Deprecated *)
 
-[@@ocaml.deprecated "Use Mark.test"]
 val marked : Group.t -> Mark.t -> bool
+[@@ocaml.deprecated "Use Mark.test"]
 (** Same as {!Mark.test}. Deprecated *)
 
-[@@ocaml.deprecated "Use Mark.all"]
 val mark_set : Group.t -> Mark.Set.t
+[@@ocaml.deprecated "Use Mark.all"]
 (** Same as {!Mark.all}. Deprecated *)

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -28,50 +28,9 @@ type t
 type re
 (** Compiled regular expression *)
 
-type groups
-(** Information about groups in a match. *)
-
-(** {2 Compilation and execution of a regular expression} *)
-
-val compile : t -> re
-(** Compile a regular expression into an executable version that can be
-    used to match strings, e.g. with {!exec}. *)
-
-val exec :
-  ?pos:int ->    (* Default: 0 *)
-  ?len:int ->    (* Default: -1 (until end of string) *)
-  re -> string -> groups
-(** [exec re str] matches [str] against the compiled expression [re],
-    and returns the matched groups if any.
-    @param pos optional beginning of the string (default 0)
-    @param len length of the substring of [str] that can be matched (default [-1],
-      meaning to the end of the string
-    @raise Not_found if the regular expression can't be found in [str]
-*)
-
-val exec_opt :
-  ?pos:int ->    (* Default: 0 *)
-  ?len:int ->    (* Default: -1 (until end of string) *)
-  re -> string -> groups option
-(** Similar to {!exec}, but returns an option instead of using an exception. *)
-
-val execp :
-  ?pos:int ->    (* Default: 0 *)
-  ?len:int ->    (* Default: -1 (until end of string) *)
-  re -> string -> bool
-(** Similar to {!exec}, but returns [true] if the expression matches,
-    and [false] if it doesn't *)
-
-val exec_partial :
-  ?pos:int ->    (* Default: 0 *)
-  ?len:int ->    (* Default: -1 (until end of string) *)
-  re -> string -> [ `Full | `Partial | `Mismatch ]
-(** More detailed version of {!exec_p} *)
-
 (** Manipulate matching groups. *)
 module Group : sig
-
-  type t = groups
+  type t
   (** Information about groups in a match. *)
 
   val get : t -> int -> string
@@ -100,8 +59,45 @@ module Group : sig
       This function is experimental. *)
 
   val pp : Format.formatter -> t -> unit
-
 end
+type groups = Group.t
+
+(** {2 Compilation and execution of a regular expression} *)
+
+val compile : t -> re
+(** Compile a regular expression into an executable version that can be
+    used to match strings, e.g. with {!exec}. *)
+
+val exec :
+  ?pos:int ->    (* Default: 0 *)
+  ?len:int ->    (* Default: -1 (until end of string) *)
+  re -> string -> Group.t
+(** [exec re str] matches [str] against the compiled expression [re],
+    and returns the matched groups if any.
+    @param pos optional beginning of the string (default 0)
+    @param len length of the substring of [str] that can be matched (default [-1],
+      meaning to the end of the string
+    @raise Not_found if the regular expression can't be found in [str]
+*)
+
+val exec_opt :
+  ?pos:int ->    (* Default: 0 *)
+  ?len:int ->    (* Default: -1 (until end of string) *)
+  re -> string -> Group.t option
+(** Similar to {!exec}, but returns an option instead of using an exception. *)
+
+val execp :
+  ?pos:int ->    (* Default: 0 *)
+  ?len:int ->    (* Default: -1 (until end of string) *)
+  re -> string -> bool
+(** Similar to {!exec}, but returns [true] if the expression matches,
+    and [false] if it doesn't *)
+
+val exec_partial :
+  ?pos:int ->    (* Default: 0 *)
+  ?len:int ->    (* Default: -1 (until end of string) *)
+  re -> string -> [ `Full | `Partial | `Mismatch ]
+(** More detailed version of {!exec_p} *)
 
 (** Marks *)
 module Mark : sig

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -153,37 +153,9 @@ module Seq : sig
     (** @since NEXT_RELEASE *)
 end
 
-module List : sig
-  val all :
-    ?pos:int ->    (** Default: 0 *)
-    ?len:int ->
-    re -> string -> Group.t list
-  (** Repeatedly calls {!exec} on the given string, starting at given position
-      and length.*)
-
-  val matches :
-    ?pos:int ->    (** Default: 0 *)
-    ?len:int ->
-    re -> string -> string list
-  (** Same as {!all}, but extracts the matched substring rather than returning
-      the whole group. This basically iterates over matched strings *)
-
-  val split :
-    ?pos:int ->    (** Default: 0 *)
-    ?len:int ->
-    re -> string -> string list
-  (** [split re s] splits [s] into chunks separated by [re]. It yields the
-      chunks themselves, not the separator. For instance this can be used with a
-      whitespace-matching re such as ["[\t ]+"]. *)
-
-  val split_full :
-    ?pos:int ->    (** Default: 0 *)
-    ?len:int ->
-    re -> string -> split_token list
-end
-
 val all : ?pos:int -> ?len:int -> re -> string -> Group.t list
-[@@ocaml.deprecated "Use List.all"]
+(** Repeatedly calls {!exec} on the given string, starting at given position and
+    length.*)
 
 type 'a gen = unit -> 'a option
 
@@ -191,19 +163,24 @@ val all_gen : ?pos:int -> ?len:int -> re -> string -> Group.t gen
 [@@ocaml.deprecated "Use Seq.all"]
 
 val matches : ?pos:int -> ?len:int -> re -> string -> string list
-[@@ocaml.deprecated "Use List.matches"]
+(** Same as {!all}, but extracts the matched substring rather than returning
+    the whole group. This basically iterates over matched strings *)
 
 val matches_gen : ?pos:int -> ?len:int -> re -> string -> string gen
 [@@ocaml.deprecated "Use Seq.matches"]
 
 val split : ?pos:int -> ?len:int -> re -> string -> string list
-[@@ocaml.deprecated "Use List.split"]
+(** [split re s] splits [s] into chunks separated by [re]. It yields the chunks
+    themselves, not the separator. For instance this can be used with a
+    whitespace-matching re such as ["[\t ]+"]. *)
 
 val split_gen : ?pos:int -> ?len:int -> re -> string -> string gen
 [@@ocaml.deprecated "Use Seq.split"]
 
 val split_full : ?pos:int -> ?len:int -> re -> string -> split_token list
-[@@ocaml.deprecated "Use List.split_full"]
+(** [split re s] splits [s] into chunks separated by [re]. It yields the chunks
+    along with the separators. For instance this can be used with a
+    whitespace-matching re such as ["[\t ]+"]. *)
 
 val split_full_gen : ?pos:int -> ?len:int -> re -> string -> split_token gen
 [@@ocaml.deprecated "Use Seq.split_full"]

--- a/lib/glob.ml
+++ b/lib/glob.ml
@@ -164,12 +164,12 @@ module State = struct
 end
 
 let one ~explicit_slash ~explicit_period =
-  Re.(compl (
+  Re.compl (
     List.concat [
-      if explicit_slash  then [char '/'] else [];
-      if explicit_period then [char '.'] else [];
+      if explicit_slash  then [Re.char '/'] else [];
+      if explicit_period then [Re.char '.'] else [];
     ]
-  ))
+  )
 
 let enclosed enclosed =
   match enclosed with

--- a/lib/group.ml
+++ b/lib/group.ml
@@ -1,0 +1,73 @@
+(* Result of a successful match. *)
+type t =
+  { s : string
+  ; marks : Automata.mark_infos
+  ; pmarks : Pmark.Set.t
+  ; gpos : int array
+  ; gcount : int
+  }
+
+let offset t i =
+  if 2 * i + 1 >= Array.length t.marks then raise Not_found;
+  let m1 = t.marks.(2 * i) in
+  if m1 = -1 then raise Not_found;
+  let p1 = t.gpos.(m1) - 1 in
+  let p2 = t.gpos.(t.marks.(2 * i + 1)) - 1 in
+  (p1, p2)
+
+let get t i =
+  let (p1, p2) = offset t i in
+  String.sub t.s p1 (p2 - p1)
+
+let start subs i = fst (offset subs i)
+
+let stop subs i = snd (offset subs i)
+
+let test t i =
+  if 2 * i >= Array.length t.marks then
+    false
+  else
+    let idx = t.marks.(2 * i) in
+    idx <> -1
+
+let dummy_offset = (-1, -1)
+
+let all_offset t =
+  let res = Array.make t.gcount dummy_offset in
+  for i = 0 to Array.length t.marks / 2 - 1 do
+    let m1 = t.marks.(2 * i) in
+    if m1 <> -1 then begin
+      let p1 = t.gpos.(m1) in
+      let p2 = t.gpos.(t.marks.(2 * i + 1)) in
+      res.(i) <- (p1 - 1, p2 - 1)
+    end
+  done;
+  res
+
+let dummy_string = ""
+
+let all t =
+  let res = Array.make t.gcount dummy_string in
+  for i = 0 to Array.length t.marks / 2 - 1 do
+    let m1 = t.marks.(2 * i) in
+    if m1 <> -1 then begin
+      let p1 = t.gpos.(m1) in
+      let p2 = t.gpos.(t.marks.(2 * i + 1)) in
+      res.(i) <- String.sub t.s (p1 - 1) (p2 - p1)
+    end
+  done;
+  res
+
+let pp fmt t =
+  let matches =
+    let offsets = all_offset t in
+    let strs = all t in
+    Array.to_list (
+      Array.init (Array.length strs) (fun i -> strs.(i), offsets.(i))
+    ) in
+  let open Fmt in
+  let pp_match fmt (str, (start, stop)) =
+    fprintf fmt "@[(%s (%d %d))@]" str start stop in
+  sexp fmt "Group" (list pp_match) matches
+
+let nb_groups t = t.gcount

--- a/lib/group.mli
+++ b/lib/group.mli
@@ -1,0 +1,52 @@
+(* Result of a successful match. *)
+type t =
+  { s : string
+  (* Input string. Matched strings are substrings of s *)
+
+  ; marks : Automata.mark_infos
+  (* Mapping from group indices to positions in gpos. group i has positions 2*i
+     - 1, 2*i + 1 in gpos. If the group wasn't matched, then its corresponding
+     values in marks will be -1,-1 *)
+
+  ; pmarks : Pmark.Set.t
+  (* Marks positions. i.e. those marks created with Re.marks *)
+
+  ; gpos : int array
+  (* Group positions. Adjacent elements are (start, stop) of group match.
+     indexed by the values in marks. So group i in an re would be the substring:
+
+     start = t.gpos.(marks.(2*i)) - 1
+     stop = t.gpos.(marks.(2*i + 1)) - 1 *)
+
+  ; gcount : int
+  (* Number of groups the regular expression contains. Matched or not *)
+  }
+
+(** Information about groups in a match. *)
+
+val get : t -> int -> string
+(** Raise [Not_found] if the group did not match *)
+
+val offset : t -> int -> int * int
+(** Raise [Not_found] if the group did not match *)
+
+val start : t -> int -> int
+(** Return the start of the match. Raise [Not_found] if the group did not match. *)
+
+val stop : t -> int -> int
+(** Return the end of the match. Raise [Not_found] if the group did not match. *)
+
+val all : t -> string array
+(** Return the empty string for each group which did not match *)
+
+val all_offset : t -> (int * int) array
+(** Return [(-1,-1)] for each group which did not match *)
+
+val test : t -> int -> bool
+(** Test whether a group matched *)
+
+val nb_groups : t -> int
+(** Returns the total number of groups defined - matched or not.
+    This function is experimental. *)
+
+val pp : Format.formatter -> t -> unit

--- a/lib/pcre.ml
+++ b/lib/pcre.ml
@@ -10,7 +10,7 @@ type split_result =
   | Group of int * string
   | NoGroup
 
-type groups = Re.groups
+type groups = Core.Group.t
 
 let re ?(flags = []) pat =
   let opts = List.map (function
@@ -116,4 +116,4 @@ let full_split ?(max=0) ~rex s =
     List.concat matches
 
 
-type substrings = Re.groups
+type substrings = Group.t

--- a/lib/pcre.ml
+++ b/lib/pcre.ml
@@ -96,7 +96,7 @@ let full_split ?(max=0) ~rex s =
   if String.length s = 0 then []
   else if max = 1 then [Text s]
   else
-    let results = Re.List.split_full rex s in
+    let results = Re.split_full rex s in
     let matches =
       List.map (function
         | `Text s -> [Text s]

--- a/lib/pcre.ml
+++ b/lib/pcre.ml
@@ -96,7 +96,7 @@ let full_split ?(max=0) ~rex s =
   if String.length s = 0 then []
   else if max = 1 then [Text s]
   else
-    let results = Re.split_full rex s in
+    let results = Re.List.split_full rex s in
     let matches =
       List.map (function
         | `Text s -> [Text s]

--- a/lib/pcre.mli
+++ b/lib/pcre.mli
@@ -2,7 +2,7 @@ type regexp = Core.re
 
 type flag = [ `CASELESS | `MULTILINE | `ANCHORED ]
 
-type groups = Core.groups
+type groups = Core.Group.t
 
 (** Result of a {!Pcre.full_split} *)
 type split_result =
@@ -42,4 +42,4 @@ val quote : string -> string
 
 (** {2 Deprecated} *)
 
-type substrings = Core.groups
+type substrings = Group.t

--- a/lib_test/test_easy.ml
+++ b/lib_test/test_easy.ml
@@ -29,28 +29,28 @@ let re_eow = Re.compile Re.eow
 let test_iter () =
   let re = Re.Posix.compile_pat "(ab)+" in
   assert_equal ~printer:pp_list
-    ["abab"; "ab"; "ab"] (Re.matches re "aabab aaabba  dab ");
+    ["abab"; "ab"; "ab"] (Re.List.matches re "aabab aaabba  dab ");
   assert_equal ~printer:pp_list
-    ["ab"; "abab"] (Re.matches ~pos:2 ~len:7 re "abab ababab");
+    ["ab"; "abab"] (Re.List.matches ~pos:2 ~len:7 re "abab ababab");
   assert_equal ~printer:pp_list
-    [""; ""] (Re.matches re_empty "ab");
+    [""; ""] (Re.List.matches re_empty "ab");
   ()
 
 let test_split () =
   assert_equal ~printer:pp_list
-    ["aa"; "bb"; "c"; "d"] (Re.split re_whitespace "aa bb c d ");
+    ["aa"; "bb"; "c"; "d"] (Re.List.split re_whitespace "aa bb c d ");
   assert_equal ~printer:pp_list
-    ["a"; "b"] (Re.split ~pos:1 ~len:4 re_whitespace "aa b c d");
+    ["a"; "b"] (Re.List.split ~pos:1 ~len:4 re_whitespace "aa b c d");
   assert_equal ~printer:pp_list
-    ["a"; "full_word"; "bc"] (Re.split re_whitespace " a full_word bc   ");
+    ["a"; "full_word"; "bc"] (Re.List.split re_whitespace " a full_word bc   ");
   assert_equal ~printer:pp_list
-    ["a"; "b"; "c"; "d"] (Re.split re_empty "abcd");
+    ["a"; "b"; "c"; "d"] (Re.List.split re_empty "abcd");
   assert_equal ~printer:pp_list
-    ["a"; "\nb"] (Re.split re_eol "a\nb");
+    ["a"; "\nb"] (Re.List.split re_eol "a\nb");
   assert_equal ~printer:pp_list
-    ["a "; "b"] (Re.split re_bow "a b");
+    ["a "; "b"] (Re.List.split re_bow "a b");
   assert_equal ~printer:pp_list
-    ["a"; " b"] (Re.split re_eow "a b");
+    ["a"; " b"] (Re.List.split re_eow "a b");
   ()
 
 let map_split_delim =
@@ -71,16 +71,16 @@ let pp_list' l =
 let test_split_full () =
   assert_equal ~printer:pp_list'
     [`T "aa"; `D " "; `T "bb"; `D " "; `T "c"; `D " "; `T "d"; `D " "]
-    (Re.split_full re_whitespace "aa bb c d " |> map_split_delim);
+    (Re.List.split_full re_whitespace "aa bb c d " |> map_split_delim);
   assert_equal ~printer:pp_list'
     [`T "a"; `D " \t"; `T "b"; `D " "]
-    (Re.split_full ~pos:1 ~len:5 re_whitespace "aa \tb c d" |> map_split_delim);
+    (Re.List.split_full ~pos:1 ~len:5 re_whitespace "aa \tb c d" |> map_split_delim);
   assert_equal ~printer:pp_list'
     [`D " "; `T "a"; `D " "; `T "full_word"; `D " "; `T "bc"; `D "   "]
-    (Re.split_full re_whitespace " a full_word bc   " |> map_split_delim);
+    (Re.List.split_full re_whitespace " a full_word bc   " |> map_split_delim);
   assert_equal ~printer:pp_list'
     [`D ""; `T "a"; `D ""; `T  "b"] (* XXX: not trivial *)
-    (Re.split_full re_empty "ab" |> map_split_delim);
+    (Re.List.split_full re_empty "ab" |> map_split_delim);
   ()
 
 let test_replace () =

--- a/lib_test/test_easy.ml
+++ b/lib_test/test_easy.ml
@@ -29,28 +29,28 @@ let re_eow = Re.compile Re.eow
 let test_iter () =
   let re = Re.Posix.compile_pat "(ab)+" in
   assert_equal ~printer:pp_list
-    ["abab"; "ab"; "ab"] (Re.List.matches re "aabab aaabba  dab ");
+    ["abab"; "ab"; "ab"] (Re.matches re "aabab aaabba  dab ");
   assert_equal ~printer:pp_list
-    ["ab"; "abab"] (Re.List.matches ~pos:2 ~len:7 re "abab ababab");
+    ["ab"; "abab"] (Re.matches ~pos:2 ~len:7 re "abab ababab");
   assert_equal ~printer:pp_list
-    [""; ""] (Re.List.matches re_empty "ab");
+    [""; ""] (Re.matches re_empty "ab");
   ()
 
 let test_split () =
   assert_equal ~printer:pp_list
-    ["aa"; "bb"; "c"; "d"] (Re.List.split re_whitespace "aa bb c d ");
+    ["aa"; "bb"; "c"; "d"] (Re.split re_whitespace "aa bb c d ");
   assert_equal ~printer:pp_list
-    ["a"; "b"] (Re.List.split ~pos:1 ~len:4 re_whitespace "aa b c d");
+    ["a"; "b"] (Re.split ~pos:1 ~len:4 re_whitespace "aa b c d");
   assert_equal ~printer:pp_list
-    ["a"; "full_word"; "bc"] (Re.List.split re_whitespace " a full_word bc   ");
+    ["a"; "full_word"; "bc"] (Re.split re_whitespace " a full_word bc   ");
   assert_equal ~printer:pp_list
-    ["a"; "b"; "c"; "d"] (Re.List.split re_empty "abcd");
+    ["a"; "b"; "c"; "d"] (Re.split re_empty "abcd");
   assert_equal ~printer:pp_list
-    ["a"; "\nb"] (Re.List.split re_eol "a\nb");
+    ["a"; "\nb"] (Re.split re_eol "a\nb");
   assert_equal ~printer:pp_list
-    ["a "; "b"] (Re.List.split re_bow "a b");
+    ["a "; "b"] (Re.split re_bow "a b");
   assert_equal ~printer:pp_list
-    ["a"; " b"] (Re.List.split re_eow "a b");
+    ["a"; " b"] (Re.split re_eow "a b");
   ()
 
 let map_split_delim =
@@ -71,16 +71,16 @@ let pp_list' l =
 let test_split_full () =
   assert_equal ~printer:pp_list'
     [`T "aa"; `D " "; `T "bb"; `D " "; `T "c"; `D " "; `T "d"; `D " "]
-    (Re.List.split_full re_whitespace "aa bb c d " |> map_split_delim);
+    (Re.split_full re_whitespace "aa bb c d " |> map_split_delim);
   assert_equal ~printer:pp_list'
     [`T "a"; `D " \t"; `T "b"; `D " "]
-    (Re.List.split_full ~pos:1 ~len:5 re_whitespace "aa \tb c d" |> map_split_delim);
+    (Re.split_full ~pos:1 ~len:5 re_whitespace "aa \tb c d" |> map_split_delim);
   assert_equal ~printer:pp_list'
     [`D " "; `T "a"; `D " "; `T "full_word"; `D " "; `T "bc"; `D "   "]
-    (Re.List.split_full re_whitespace " a full_word bc   " |> map_split_delim);
+    (Re.split_full re_whitespace " a full_word bc   " |> map_split_delim);
   assert_equal ~printer:pp_list'
     [`D ""; `T "a"; `D ""; `T  "b"] (* XXX: not trivial *)
-    (Re.List.split_full re_empty "ab" |> map_split_delim);
+    (Re.split_full re_empty "ab" |> map_split_delim);
   ()
 
 let test_replace () =

--- a/lib_test/test_re.ml
+++ b/lib_test/test_re.ml
@@ -1,6 +1,8 @@
+module L = List
 open Re
 open OUnit2
 open Fort_unit
+module List = L
 
 let re_match ?pos ?len r s res =
   expect_equal_app

--- a/re.opam
+++ b/re.opam
@@ -1,4 +1,4 @@
-opam-version: "1.2"
+opam-version: "2.0"
 
 maintainer: "rudi.grinberg@gmail.com"
 authors: [
@@ -11,18 +11,27 @@ authors: [
 license: "LGPL-2.0 with OCaml linking exception"
 homepage: "https://github.com/ocaml/ocaml-re"
 bug-reports: "https://github.com/ocaml/ocaml-re/issues"
-dev-repo: "https://github.com/ocaml/ocaml-re.git"
+dev-repo: "git+https://github.com/ocaml/ocaml-re.git"
 
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-build-test: [["dune" "runtest" "-p" name "-j" jobs]]
 
 depends: [
+  "ocaml" {>= "4.02"}
   "dune" {build}
-  "ounit" {test}
+  "ounit" {with-test}
   "seq"
 ]
 
-available: [ocaml-version >= "4.02.3"]
+synopsis: "RE is a regular expression library for OCaml"
+description: """
+Pure OCaml regular expressions with:
+* Perl-style regular expressions (module Re.Perl)
+* Posix extended regular expressions (module Re.Posix)
+* Emacs-style regular expressions (module Re.Emacs)
+* Shell-style file globbing (module Re.Glob)
+* Compatibility layer for OCaml's built-in Str module (module Re.Str)
+"""


### PR DESCRIPTION
The biggest change is the move of the gen/seq/list modules to their own sub modules. This has a couple of advantages (plus I like names without suffixes more):

* We'll be able to enforce that they all have the same interfaces via module types (I'll do that later).

* Once we re-organize the library a little more, we'll be able to have these unused functions removed by the dead code elimination.

I've also moved a few other chunks of code to their own modules. `core.ml` is getting quite heavy, so I think it's a step in the right direction.

The added comments + better names are self explanatory I think.