### PR TITLE
Glob: Double asterisk match including slash

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ Unreleased
 ----------
 
 * Add the `[:alpha:]` character class in `Re.Perl` (#169)
+* Double asterisk (`**`) in `Re.Glob` (#172)
+  Like `*` but also match `/` characters when `pathname` is set.
 
 1.9.0 (05-Apr-2019)
 -------------------

--- a/lib/glob.ml
+++ b/lib/glob.ml
@@ -34,6 +34,7 @@ type piece =
   | Any_but of enclosed list
   | One
   | Many
+  | ManyMany
 
 type t = piece list
 
@@ -75,7 +76,9 @@ let of_string s : t =
 
   let piece () =
     if read '*'
-    then Many
+    then if read '*'
+      then ManyMany
+      else Many
     else if read '?'
     then One
     else if not (read '[')
@@ -188,6 +191,15 @@ let enclosed_set ~explicit_slash ~explicit_period kind set =
 let exactly state c =
   State.append state (Re.char c) ~am_at_start_of_component:(c = '/')
 
+let many_many ~explicit_period =
+  (* We explicitly match periods only at the very beginning if [explicit_period] *)
+  Re.opt (
+    Re.seq [
+      one         ~explicit_slash:false ~explicit_period;
+      Re.rep (one ~explicit_slash:false ~explicit_period:false);
+    ]
+  )
+
 let many (state : State.t) =
   let explicit_slash = State.explicit_slash state in
   let explicit_period = State.explicit_period state in
@@ -214,15 +226,18 @@ let many (state : State.t) =
     (* [maybe_empty] is the default translation of Many, except in some special cases.
     *)
     let maybe_empty = Re.opt not_empty in
-    let enclosed_set state kind set =
+    let then_ state then_ =
       State.append state (Re.alt [
-        enclosed_set kind set ~explicit_slash:true ~explicit_period:true;
+        then_ ~explicit_period:true;
         Re.seq [
           not_empty;
           (* Since [not_empty] matched, subsequent dots are not leading. *)
-          enclosed_set kind set ~explicit_slash:true ~explicit_period:false;
+          then_ ~explicit_period:false;
         ];
       ])
+    in
+    let then_enclosed_set state kind set =
+      then_ state (enclosed_set kind set ~explicit_slash:true)
     in
     let rec lookahead state =
       match State.next state with
@@ -239,8 +254,10 @@ let many (state : State.t) =
         exactly state c
       (* glob *? === glob ?* *)
       | Some (One, state) -> State.append state not_empty
-      | Some (Any_of enclosed, state) -> enclosed_set state `Any_of enclosed
-      | Some (Any_but enclosed, state) -> enclosed_set state `Any_but enclosed
+      | Some (Any_of enclosed, state) -> then_enclosed_set state `Any_of enclosed
+      | Some (Any_but enclosed, state) -> then_enclosed_set state `Any_but enclosed
+      (* * then ** === ** *)
+      | Some (ManyMany, state) -> then_ state many_many
     in
     lookahead state
   end
@@ -256,6 +273,7 @@ let piece state piece =
   | Any_but enclosed ->
     State.append state (enclosed_set `Any_but ~explicit_slash ~explicit_period enclosed)
   | Exactly c -> exactly state c
+  | ManyMany -> State.append state (many_many ~explicit_period)
 
 let glob ~pathname ~period glob =
   let rec loop state =

--- a/lib/glob.ml
+++ b/lib/glob.ml
@@ -38,7 +38,7 @@ type piece =
 
 type t = piece list
 
-let of_string s : t =
+let of_string ~double_asterisk s : t =
   let i = ref 0 in
   let l = String.length s in
   let eos () = !i = l in
@@ -76,7 +76,7 @@ let of_string s : t =
 
   let piece () =
     if read '*'
-    then if read '*'
+    then if double_asterisk && read '*'
       then ManyMany
       else Many
     else if read '?'
@@ -288,10 +288,11 @@ let glob
       ?(pathname = true)
       ?(period = true)
       ?(expand_braces = false)
+      ?(double_asterisk = true)
       s
   =
   let to_re s =
-    let re = glob ~pathname ~period (of_string s) in
+    let re = glob ~pathname ~period (of_string ~double_asterisk s) in
     if anchored
     then Re.whole_string re
     else re

--- a/lib/glob.ml
+++ b/lib/glob.ml
@@ -208,7 +208,7 @@ let many_many state =
       Re.rep (
         Re.seq [
           Re.char '/';
-          match_component ~explicit_period
+          Re.opt (match_component ~explicit_period);
         ]
       );
     ])

--- a/lib/glob.mli
+++ b/lib/glob.mli
@@ -46,7 +46,8 @@ val glob :
 
     [pathname]: If this flag is set, match a slash in string only with a slash in pattern
     and not by an asterisk ('*') or a question mark ('?') metacharacter, nor by a bracket
-    expression ('[]') containing a slash. Defaults to true.
+    expression ('[]') containing a slash. Double asterisk ('**') will match anything,
+    including slash characters. Defaults to true.
 
     [period]: If this flag is set, a leading period in string has to be matched exactly by
     a period in pattern. A period is considered to be leading if it is the first

--- a/lib/glob.mli
+++ b/lib/glob.mli
@@ -29,6 +29,7 @@ val glob :
   ?pathname:bool ->
   ?period:bool ->
   ?expand_braces:bool ->
+  ?double_asterisk:bool ->
   string ->
   Core.t
 (** Implements the semantics of shells patterns. The returned regular
@@ -46,8 +47,7 @@ val glob :
 
     [pathname]: If this flag is set, match a slash in string only with a slash in pattern
     and not by an asterisk ('*') or a question mark ('?') metacharacter, nor by a bracket
-    expression ('[]') containing a slash. Double asterisk ('**') will match anything,
-    including slash characters. Defaults to true.
+    expression ('[]') containing a slash. Defaults to true.
 
     [period]: If this flag is set, a leading period in string has to be matched exactly by
     a period in pattern. A period is considered to be leading if it is the first
@@ -56,7 +56,10 @@ val glob :
 
     If [expand_braces] is true, braced sets will expand into multiple globs,
     e.g. a\{x,y\}b\{1,2\} matches axb1, axb2, ayb1, ayb2.  As specified for bash, brace
-    expansion is purely textual and can be nested. Defaults to false. *)
+    expansion is purely textual and can be nested. Defaults to false.
+
+    [double_asterisk]: If this flag is set, double asterisks ('**') will match slash
+    characters, even if [pathname] is set. Default to true. *)
 
 val glob' : ?anchored:bool -> bool -> string -> Core.t
 (** Same, but allows to choose whether dots at the beginning of a

--- a/lib/glob.mli
+++ b/lib/glob.mli
@@ -59,7 +59,8 @@ val glob :
     expansion is purely textual and can be nested. Defaults to false.
 
     [double_asterisk]: If this flag is set, double asterisks ('**') will match slash
-    characters, even if [pathname] is set. Default to true. *)
+    characters, even if [pathname] is set. The [period] flag still applies. Default to
+    true. *)
 
 val glob' : ?anchored:bool -> bool -> string -> Core.t
 (** Same, but allows to choose whether dots at the beginning of a

--- a/lib_test/test_glob.ml
+++ b/lib_test/test_glob.ml
@@ -85,4 +85,32 @@ let _ =
   assert (re_match    (glob ~expand_braces:true "{foo,far}bar") "farbar"      );
   assert (re_mismatch (glob ~expand_braces:true "{foo,far}bar") "{foo,far}bar");
 
+  (* Double asterisk *)
+  let anchored = true in
+  assert (re_match    (glob ~anchored "**") "foobar");
+  assert (re_match    (glob ~anchored "**") "foo/bar");
+  assert (re_match    (glob ~anchored "**/bar") "foo/bar");
+  assert (re_match    (glob ~anchored "**/bar") "foo/far/bar");
+  assert (re_mismatch (glob ~anchored "foo/**") "foo");
+  assert (re_match    (glob ~anchored "foo/**") "foo/bar");
+  assert (re_match    (glob ~anchored "foo/**") "foo/far/bar");
+  assert (re_match    (glob ~anchored "foo/**/bar") "foo/far/bar");
+  assert (re_match    (glob ~anchored "foo/**/bar") "foo/far/oof/bar");
+  assert (re_match    (glob ~anchored "foo/**bar") "foo/far/oofbar");
+  assert (re_match    (glob ~anchored "foo/**bar") "foo/bar");
+
+  (* Interaction with [~period] *)
+  let period = true in
+  assert (re_mismatch (glob ~anchored ~period "**") ".foobar");
+  assert (re_mismatch (glob ~anchored ~period "**") ".foo/bar");
+  assert (re_mismatch (glob ~anchored ~period "foo/**") "foo/.bar");
+  assert (re_match    (glob ~anchored ~period ".**") ".foobar");
+  assert (re_match    (glob ~anchored ~period ".**") ".foo/bar");
+  assert (re_match    (glob ~anchored ~period "foo/.**") "foo/.bar");
+
+  let period = false in
+  assert (re_match    (glob ~anchored ~period "**") ".foobar");
+  assert (re_match    (glob ~anchored ~period "**") ".foo/bar");
+  assert (re_match    (glob ~anchored ~period "foo/**") "foo/.bar");
+
   run_test_suite "test_re";

--- a/lib_test/test_glob.ml
+++ b/lib_test/test_glob.ml
@@ -104,6 +104,11 @@ let _ =
   assert (re_mismatch (glob ~anchored ~period "**") ".foobar");
   assert (re_mismatch (glob ~anchored ~period "**") ".foo/bar");
   assert (re_mismatch (glob ~anchored ~period "foo/**") "foo/.bar");
+  assert (re_mismatch (glob ~anchored ~period "**") "foo/.bar/bat");
+  assert (re_mismatch (glob ~anchored ~period "foo/**/bat") "foo/.bar/bat");
+  assert (re_mismatch (glob ~anchored ~period "/**/bat") "/foo/.bar/bat");
+  assert (re_mismatch (glob ~anchored ~period "/**/bat") "/.bar/bat");
+  assert (re_mismatch (glob ~anchored ~period "/**bat") "/bar/.bat");
   assert (re_match    (glob ~anchored ~period ".**") ".foobar");
   assert (re_match    (glob ~anchored ~period ".**") ".foo/bar");
   assert (re_match    (glob ~anchored ~period "foo/.**") "foo/.bar");
@@ -112,5 +117,10 @@ let _ =
   assert (re_match    (glob ~anchored ~period "**") ".foobar");
   assert (re_match    (glob ~anchored ~period "**") ".foo/bar");
   assert (re_match    (glob ~anchored ~period "foo/**") "foo/.bar");
+  assert (re_match    (glob ~anchored ~period "**") "foo/.bar/bat");
+  assert (re_match    (glob ~anchored ~period "foo/**/bat") "foo/.bar/bat");
+  assert (re_match    (glob ~anchored ~period "/**/bat") "/foo/.bar/bat");
+  assert (re_match    (glob ~anchored ~period "/**/bat") "/.bar/bat");
+  assert (re_match    (glob ~anchored ~period "/**bat") "/bar/.bat");
 
   run_test_suite "test_re";

--- a/lib_test/test_glob.ml
+++ b/lib_test/test_glob.ml
@@ -98,6 +98,8 @@ let _ =
   assert (re_match    (glob ~anchored "foo/**/bar") "foo/far/oof/bar");
   assert (re_match    (glob ~anchored "foo/**bar") "foo/far/oofbar");
   assert (re_match    (glob ~anchored "foo/**bar") "foo/bar");
+  assert (re_match    (glob ~anchored "/**") "//foo");
+  assert (re_match    (glob ~anchored "**") "foo//bar");
 
   (* Interaction with [~period] *)
   let period = true in


### PR DESCRIPTION
Hi,

This PR adds support for double asterisks (`**`) to `Glob`.
It is like `*` but also matches `/` characters, even when `pathname` is set.

For example, `foo/**` will match both `foo/bar` and `foo/bar/baz`.

The `period` flag still work, `foo/**` won't match `foo/.bar` but `foo/.**` will.

Related to issue https://github.com/ocaml/ocaml-re/issues/171
This is useful in OCamlformat, where the matching is done on the whole path: https://github.com/ocaml-ppx/ocamlformat/issues/1234