### PR TITLE
Remove dot `.merlin` (and fix benchmark)

### DIFF
--- a/benchmarks/.merlin
+++ b/benchmarks/.merlin
@@ -1,3 +1,0 @@
-S ../lib
-B ../_build/**
-PKG core_bench

--- a/benchmarks/benchmark.ml
+++ b/benchmarks/benchmark.ml
@@ -1,5 +1,5 @@
-open Core.Std
-open Core_bench.Std
+open Core
+open Core_bench
 
 module Http = struct
   open Re
@@ -63,7 +63,7 @@ let tex_ignore_re =
       match String.strip s with
       | "" -> None
       | s -> Some s)
-  |> List.map ~f:Re_glob.glob
+  |> List.map ~f:Re.Glob.glob
   |> Re.alt
 
 let tex_ignore_filesnames = In_channel.read_lines "benchmarks/files"
@@ -82,7 +82,7 @@ let media_type_re =
 
 (* Taken from https://github.com/rgrinberg/ocaml-uri/blob/903ef1010f9808d6f3f6d9c1fe4b4eabbd76082d/lib/uri.ml*)
 let uri_reference =
-  Re_posix.re "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
+  Re.Posix.re "^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\\?([^#]*))?(#(.*))?"
 
 let uris =
   [ "https://google.com"
@@ -120,8 +120,8 @@ let rec read_all_http pos re reqs =
 
 let rec drain_gen gen =
   match gen () with
-  | None -> ()
-  | Some _ -> drain_gen gen
+  | Seq.Nil -> ()
+  | Cons (_, tail) -> drain_gen tail
 
 let benchmarks =
   let benches =
@@ -150,7 +150,7 @@ let benchmarks =
           )
       ; Test.create ~name:"all_gen group" (fun () ->
             http_requests
-            |> Re.all_gen requests_g
+            |> Re.Seq.all requests_g
             |> drain_gen
           )
       ] |> Test.create_group ~name:"auto" in


### PR DESCRIPTION
In a near future `.merlin` files won't be promoted to sources by dune anymore. This break the build of projects using dune with hard-coded `.merlin` files in their sources.

This PR removes the (useless since the project moved to dune) file `benchmarks/ .merlin`.

I also took the opportunity to correct the benchmark code that was not up-to-date with some api changes of `Core` and `Re` itself.

<details><summary>Useless bonus: results under WSL, core i7 8700 and 16go ram</summary><p>

```
{{Estimated testing time 4m (24 benchmarks x 10s). Change using '-quota'.
┌──────────────────────────────────┬──────────────┬────────────┬──────────┬──────────┬────────────┐
│ Name                             │     Time/Run │    mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├──────────────────────────────────┼──────────────┼────────────┼──────────┼──────────┼────────────┤
│ 20 zeroes/exec/case 0            │     117.02ns │     65.00w │          │          │      0.07% │
│ 20 zeroes/execp/case 0           │      78.36ns │     31.00w │          │          │      0.04% │
│ 20 zeroes/exec_opt/case 0        │     116.17ns │     67.00w │          │          │      0.07% │
│ lots of a's/exec/case 0          │     374.38ns │     42.00w │          │          │      0.21% │
│ lots of a's/execp/case 0         │     296.20ns │     31.00w │          │          │      0.17% │
│ lots of a's/exec_opt/case 0      │     367.30ns │     44.00w │          │          │      0.21% │
│ media type match/exec/case 0     │      63.60ns │     42.00w │          │          │      0.04% │
│ media type match/execp/case 0    │      44.70ns │     31.00w │          │          │      0.03% │
│ media type match/exec_opt/case 0 │      63.63ns │     44.00w │          │          │      0.04% │
│ uri/exec/case 0                  │      98.58ns │     42.00w │          │          │      0.06% │
│ uri/exec/case 1                  │     180.58ns │     42.00w │          │          │      0.10% │
│ uri/exec/case 2                  │      96.96ns │     42.00w │          │          │      0.05% │
│ uri/execp/case 0                 │      73.51ns │     31.00w │          │          │      0.04% │
│ uri/execp/case 1                 │     142.26ns │     31.00w │          │          │      0.08% │
│ uri/execp/case 2                 │      68.42ns │     31.00w │          │          │      0.04% │
│ uri/exec_opt/case 0              │      98.00ns │     44.00w │          │          │      0.06% │
│ uri/exec_opt/case 1              │     181.64ns │     44.00w │          │          │      0.10% │
│ uri/exec_opt/case 2              │      95.32ns │     44.00w │          │          │      0.05% │
│ tex gitignore/execp              │ 138_939.04ns │ 25_985.06w │    0.24w │    0.24w │     78.34% │
│ tex gitignore/exec_opt           │ 177_354.41ns │ 38_354.84w │    0.51w │    0.51w │    100.00% │
│ http/manual/no group             │  74_371.07ns │     31.43w │   -0.67w │   -0.66w │     41.93% │
│ http/manual/group                │  66_401.15ns │     29.51w │          │          │     37.44% │
│ http/auto/execp no group         │  73_574.85ns │      2.59w │   -1.32w │   -1.31w │     41.48% │
│ http/auto/all_gen group          │  67_492.79ns │     47.11w │          │          │     38.06% │
└──────────────────────────────────┴──────────────┴────────────┴──────────┴──────────┴────────────┘
```

</p></details>