### PR TITLE
Improve handling of word boundaries, fix #146

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Unreleased
+--------------------
+
+* Improve handling of word boundaries (#179)
+
 1.10.3 (13-Sep-2021)
 --------------------
 

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -631,11 +631,11 @@ let rec translate ids kind ign_group ign_case greedy pos cache c = function
   | Beg_of_word ->
     (A.seq ids `First
        (A.after ids Category.(inexistant ++ not_letter))
-       (A.before ids Category.(inexistant ++ letter)),
+       (A.before ids Category.letter),
      kind)
   | End_of_word ->
     (A.seq ids `First
-       (A.after ids Category.(inexistant ++ letter))
+       (A.after ids Category.letter)
        (A.before ids Category.(inexistant ++ not_letter)),
      kind)
   | Not_bound ->
@@ -643,8 +643,8 @@ let rec translate ids kind ign_group ign_case greedy pos cache c = function
                   (A.after ids Category.letter)
                   (A.before ids Category.letter);
                 A.seq ids `First
-                  (A.after ids Category.letter)
-                  (A.before ids Category.letter)],
+                  (A.after ids Category.(inexistant ++ not_letter))
+                  (A.before ids Category.(inexistant ++ not_letter))],
      kind)
   | Beg_of_str ->
     (A.after ids Category.inexistant, kind)

--- a/lib_test/test_re.ml
+++ b/lib_test/test_re.ml
@@ -176,12 +176,16 @@ let _ =
     re_match  (seq [bow; char 'a'])       "a"     [|(0,1)|];
     re_match  (seq [bow; char 'a'])       "bb aa" [|(3,4)|];
     re_fail   (seq [bow; char 'a'])       "ba ba";
+    re_fail   bow                         ";";
+    re_fail   bow                         "";
   );
 
   expect_pass "eow" (fun () ->
     re_match  (seq [char 'a'; eow])       "a"     [|(0,1)|];
     re_match  (seq [char 'a'; eow])       "bb aa" [|(4,5)|];
     re_fail   (seq [char 'a'; eow])       "ab ab";
+    re_fail   eow                         ";";
+    re_fail   eow                         "";
   );
 
   expect_pass "bos" (fun () ->
@@ -222,10 +226,13 @@ let _ =
     re_match  (word (str "aa"))           "aa"    [|(0,2)|];
     re_match  (word (str "aa"))           "bb aa" [|(3,5)|];
     re_fail   (word (str "aa"))           "aaa";
+    re_fail   (word (str ""))             "";
   );
 
   expect_pass "not_boundary" (fun () ->
     re_match (seq [not_boundary; char 'b'; not_boundary])  "abc"  [|(1,2)|];
+    re_match (seq [char ';'; not_boundary; char ';'])      ";;"   [|(0,2)|];
+    re_match (seq [not_boundary; char ';'; not_boundary])  ";"    [|(0,1)|];
     re_fail  (seq [not_boundary; char 'a'])  "abc";
     re_fail  (seq [char 'c'; not_boundary])  "abc";
   );


### PR DESCRIPTION
# What changed

In addition to the minimal fix suggested by Vouillon in #146, this PR
allows `Category.inexistant` characters (i.e., `bos` and `eos`) in the
following places:

1. before `bow`
2. after `eow`
3. on both sides of `not_boundary` (but not one side alone)

# Justification of change

That minimal fix would still give an unintuitive and unconventional
interpretation of word boundaries where `bos` and `eos`...

1. are accepted on both sides of a word boundary (`bow` or `eow`)
2. are not accepted on either side of a `not_boundary`

With the minimal fix, `bow` and `eow` matches would not need to have a
word between them. E.g.,

1. in `""`, both `bow` and `eow` would match at position 0 with
   nothing between them
2. in `"#"`, `bow` would match before the `#` and `eow` after the `#`,
   even though `#` is not a word character.

In contrast, the convention in other regex libraries is that `bos` and
`eos` are not words:

1. [Ruby](https://rubular.com/r/7jdsGlU3LOPrX2)
2. [Python](https://pythex.org/?regex=%5Cb&test_string=%23&ignorecase=0&multiline=0&dotall=0&verbose=0)
3. [re2 syntax reference](https://github.com/google/re2/wiki/Syntax).
4. PCRE: can't permalink, but you can check on https://regexpal.com .
5. JavaScript: ditto, https://regexpal.com .

This PR implements this more conventional behavior.

# Use case

Jane Street is migrating from `Re2` to `Re` by writing a wrapper that
implements the `Re2` interface on top of `Re`.

In most cases where `Re2` disagrees with `Re`, we either worked around
it in the wrapper or let the wrapper diverge from real `Re2`.

This seems like a case where we can't work around it, and where `Re2`
has the more intuitive and conventional behavior.