### PR TITLE
make `witness` handle empty regular expressions better

### DIFF
--- a/lib/core.mli
+++ b/lib/core.mli
@@ -493,9 +493,10 @@ end with type outer := t
 val witness : t -> string
 (** [witness r] generates a string [s] such that [execp (compile r) s] is true.
 
-    Be warned that this function is buggy because it ignores zero-width
-    assertions like beginning of words. As a result it can generate incorrect
-    results. *)
+   This function currently has the following bug: it ignores
+   zero-width assertions (beginning/end of words, beginning/end of
+   string, etc). So when using such constructions, it is possible
+   that the regular expression doesn't match the returned witness. *)
 
 (** {2 Deprecated functions} *)
 

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -493,6 +493,8 @@ end with type outer := t
 val witness : t -> string
 (** [witness r] generates a string [s] such that [execp (compile r) s] is true.
 
+   Raise [Not_found] if the regular expression is empty.
+
    This function currently has the following bug: it ignores
    zero-width assertions (beginning/end of words, beginning/end of
    string, etc). So when using such constructions, it is possible

--- a/lib_test/test_re.ml
+++ b/lib_test/test_re.ml
@@ -1,6 +1,5 @@
 module L = List
 open Re
-open OUnit2
 open Fort_unit
 module List = L
 
@@ -438,13 +437,21 @@ let _ =
   );
 
   expect_pass "witness" (fun () ->
-      let t r e = assert_equal ~printer:(fun x -> x) (witness r) e in
+      let t r e =
+        match e with
+        | None -> expect_eq_str not_found () witness empty
+        | Some str -> expect_eq_str id str witness r
+      in
 
-      t (set "ac") "a";
-      t (repn (str "foo") 3 None) "foofoofoo";
-      t (alt [char 'c' ; char 'd']) "c";
-      t (no_case (str "test")) "TEST";
-      t eol ""
+      t (set "ac") (Some "a");
+      t (repn (str "foo") 3 None) (Some "foofoofoo");
+      t (alt [char 'c' ; char 'd']) (Some "c");
+      t (no_case (str "test")) (Some "TEST");
+      t (seq [str "a"; str "b"]) (Some "ab");
+      t eol (Some "");
+      t empty None;
+      t (seq [str "a"; empty]) None;
+      t (alt [empty ; set "" ; set "ab"]) (Some "a");
     );
 
   (* Fixed bugs *)


### PR DESCRIPTION
Since I was looking at the documentation of `witness` in the other pull request, I noticed this problem. This one is easy to fix, so let's fix it instead of documenting it.

This adds a call to `List.filter_map`, which is only available since 4.08. I don't know what versions ocaml-re aims to support.

Please ignore the first commit in this pull request. It's #183, so it'll go away once its status is decided.