### PR TITLE
Glob: Make double asterisk match zero or more directories

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@ Unreleased
 * Add the `[:alpha:]` character class in `Re.Perl` (#169)
 * Double asterisk (`**`) in `Re.Glob` (#172)
   Like `*` but also match `/` characters when `pathname` is set.
+* Double asterisk should match 0 or more directories unless in trailing
+  position. (#192, fixes #185)
 
 1.9.0 (05-Apr-2019)
 -------------------

--- a/lib/glob.ml
+++ b/lib/glob.ml
@@ -75,23 +75,30 @@ let of_string ~double_asterisk s : t =
   in
 
   let piece () =
-    if read '*'
-    then if double_asterisk && read '*'
-      then ManyMany
-      else Many
+    if read '/' then
+      if read '*' then
+        if double_asterisk && read '*' then
+          if eos () then [ManyMany; Exactly('/')]
+          else [ManyMany]
+        else [Many; Exactly('/')]
+      else [Exactly('/')]
+    else if read '*'
+      then if double_asterisk && read '*'
+        then [ManyMany]
+        else [Many]
     else if read '?'
-    then One
+    then [One]
     else if not (read '[')
-    then Exactly (char ())
+    then [Exactly (char ())]
     else if read '^' || read '!'
-    then Any_but (enclosed ())
-    else Any_of (enclosed ())
+    then [Any_but (enclosed ())]
+    else [Any_of (enclosed ())]
   in
 
   let rec loop pieces =
     if eos ()
     then List.rev pieces
-    else loop (piece () :: pieces)
+    else loop (piece () @ pieces)
   in
 
   loop []

--- a/lib/glob.ml
+++ b/lib/glob.ml
@@ -49,10 +49,10 @@ let of_string ~double_asterisk s : t =
   in
 
   (**
-   [lookahead pattern] will attempt to read [pattern] and will return [true] if it was successful.
+   [read_ahead pattern] will attempt to read [pattern] and will return [true] if it was successful.
    If it fails, it will return [false] and not increment the read index.
   *)
-  let lookahead pattern =
+  let read_ahead pattern =
     let pattern_len = String.length pattern in
     (* if the pattern we are looking for exeeds the remaining length of s, return false immediately *)
     if !i + pattern_len >= l then
@@ -95,7 +95,7 @@ let of_string ~double_asterisk s : t =
   in
 
   let piece () =
-    if double_asterisk && lookahead "/**" && not (eos ())
+    if double_asterisk && read_ahead "/**" && not (eos ())
     then ManyMany
     else if read '*'
     then if double_asterisk && read '*'

--- a/lib_test/test_glob.ml
+++ b/lib_test/test_glob.ml
@@ -101,6 +101,16 @@ let _ =
   assert (re_match    (glob ~anchored "/**") "//foo");
   assert (re_match    (glob ~anchored "**") "foo//bar");
 
+  assert (re_match    (glob ~anchored "foo/bar/**/*.ml") "foo/bar/baz/foobar.ml");
+  assert (re_match    (glob ~anchored "foo/bar/**/*.ml") "foo/bar/foobar.ml");
+
+  assert (re_match    (glob ~anchored "foo/**/bar/**/baz") "foo/bar/baz");
+  assert (re_match    (glob ~anchored "foo/**/bar/**/baz") "foo/bar/x/y/z/baz");
+  assert (re_match    (glob ~anchored "foo/**/bar/**/baz") "foo/x/y/z/bar/baz");
+  assert (re_match    (glob ~anchored "foo/**/bar/**/baz") "foo/bar/x/bar/x/baz");
+  assert (re_mismatch (glob ~anchored "foo/**/bar/**/baz") "foo/bar/../x/baz");
+  assert (re_mismatch (glob ~anchored "foo/**/bar/**/baz") "foo/bar/./x/baz");
+
   (* Interaction with [~period] *)
   let period = true in
   assert (re_mismatch (glob ~anchored ~period "**") ".foobar");

--- a/lib_test/test_glob.ml
+++ b/lib_test/test_glob.ml
@@ -98,6 +98,7 @@ let _ =
   assert (re_match    (glob ~anchored "foo/**/bar") "foo/far/oof/bar");
   assert (re_match    (glob ~anchored "foo/**bar") "foo/far/oofbar");
   assert (re_match    (glob ~anchored "foo/**bar") "foo/bar");
+  assert (re_match    (glob ~anchored "foo/**bar") "foo/foobar");
   assert (re_match    (glob ~anchored "/**") "//foo");
   assert (re_match    (glob ~anchored "**") "foo//bar");
 


### PR DESCRIPTION
Fixes #185 

I don't know, if this is a good implementation for the fix (I rather doubt it) but maybe it can be used as a starting point to further improve on.

As I already noted in the issue, the problem was, that the parser saw the `/`'s as explicitly set characters that needed to be present.
I am now checking, if the double asterisk has leading or trailing slashes and ignore them if there are any.
If the trailing slash is in the last place, I do _not_ ignore it, so the test on [line 94](https://github.com/eWert-Online/ocaml-re/blob/690a002571be79190c8362b4b48b8348bf99d7ab/lib_test/test_glob.ml#L94) does not fail.

If you have any suggestions for an implementation that is easier to understand / read, I would be happy to hear it 😄 