### PR TITLE
Glob: do not skip over backslashes under Windows

### DIFF
--- a/lib/glob.ml
+++ b/lib/glob.ml
@@ -61,7 +61,7 @@ let of_string ~double_asterisk s : t =
       try
         for j = 0 to pattern_len - 1 do
           let found = not (eos ()) && s.[!i + j] = pattern.[j] in
-          if not found then raise_no_trace Exit;
+          if not found then raise_notrace Exit;
         done;
         i := !i + pattern_len;
         true

--- a/lib/glob.ml
+++ b/lib/glob.ml
@@ -69,7 +69,7 @@ let of_string ~double_asterisk s : t =
   in
 
   let char () =
-    ignore (read '\\' : bool);
+    if not Sys.win32 then ignore (read '\\' : bool);
     if eos () then raise Parse_error;
     let r = s.[!i] in
     incr i;


### PR DESCRIPTION
(The first commit is just to fix the build following #192)

Currently `Glob` skips over backslashes, interpreting the character following one "literally". This is wrong on Windows, where backslashes are perfectly good characters in pathnames. This commit makes the "skip over backslash" logic only apply when not on Windows.

Note that there may be other fixes necessary to work well under Windows, but this is already an improvement.

This PR fixes (at least in some cases) the issue reported in https://github.com/ocaml-ppx/ocamlformat/issues/1773