### PR TITLE
Glob: add ~backslash_escapes to control handling of backslashes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Unreleased
   Like `*` but also match `/` characters when `pathname` is set.
 * Double asterisk should match 0 or more directories unless in trailing
   position. (#192, fixes #185)
+* Glob: add optional argument `?backslash_escapes` to control interpretation of
+  backslashes (useful under Windows) (#197, #198)
 
 1.9.0 (05-Apr-2019)
 -------------------

--- a/lib/glob.mli
+++ b/lib/glob.mli
@@ -27,6 +27,7 @@ exception Parse_error
 val glob :
   ?anchored:bool ->
   ?pathname:bool ->
+  ?backslash_escapes:bool ->
   ?period:bool ->
   ?expand_braces:bool ->
   ?double_asterisk:bool ->
@@ -39,8 +40,6 @@ val glob :
     '?' matches a single character.
     A sequence '[...]' matches any one of the enclosed characters.
     A sequence '[^...]' or '[!...]' matches any character *but* the enclosed characters.
-    A backslash escapes the following character.  The last character of the string cannot
-    be a backslash.
 
     [anchored] controls whether the regular expression will only match entire
     strings. Defaults to false.
@@ -48,6 +47,11 @@ val glob :
     [pathname]: If this flag is set, match a slash in string only with a slash in pattern
     and not by an asterisk ('*') or a question mark ('?') metacharacter, nor by a bracket
     expression ('[]') containing a slash. Defaults to true.
+
+    [backslash_escapes]: If this flag is set, then a backslash will escape the
+    character following it, and it an error if the last character of the string
+    is a backslash. Otherwise, backslashes are considered equivalent to forward
+    slashes (useful when globbing Windows paths). Defaults to true.
 
     [period]: If this flag is set, a leading period in string has to be matched exactly by
     a period in pattern. A period is considered to be leading if it is the first


### PR DESCRIPTION
This is a follow-up to #197, which had only a partial fix for the handling of backslashes in the `Glob` module. In this PR, we add a new optional argument to `Glob.glob`, namely `~backslash_escapes`. When `true` (the default), behaviour is unchanged: backslashes escape the following character. When `false`, backslashes are taken to be equivalent to forward slashes, which is useful when globbing Windows paths.