### PR TITLE
Tweak 'backslash' API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+Working
+-------
+
+* Glob: change optional argument `?backslash_escapes` to `?match_backslashes`.
+  The interpretation of backslashes in the glob pattern remains unchanged with
+  the new option, but forward slashes match backslashes when activated (#199)
+
 1.10.2 (09-Sep-2021)
 --------------------
 

--- a/lib/glob.mli
+++ b/lib/glob.mli
@@ -27,7 +27,7 @@ exception Parse_error
 val glob :
   ?anchored:bool ->
   ?pathname:bool ->
-  ?backslash_escapes:bool ->
+  ?match_backslashes:bool ->
   ?period:bool ->
   ?expand_braces:bool ->
   ?double_asterisk:bool ->
@@ -40,6 +40,8 @@ val glob :
     '?' matches a single character.
     A sequence '[...]' matches any one of the enclosed characters.
     A sequence '[^...]' or '[!...]' matches any character *but* the enclosed characters.
+    A backslash escapes the following character.  The last character of the string cannot
+    be a backslash.
 
     [anchored] controls whether the regular expression will only match entire
     strings. Defaults to false.
@@ -48,10 +50,10 @@ val glob :
     and not by an asterisk ('*') or a question mark ('?') metacharacter, nor by a bracket
     expression ('[]') containing a slash. Defaults to true.
 
-    [backslash_escapes]: If this flag is set, then a backslash will escape the
-    character following it, and it an error if the last character of the string
-    is a backslash. Otherwise, backslashes are considered equivalent to forward
-    slashes (useful when globbing Windows paths). Defaults to true.
+    [match_backslashes]: If this flag is set, a forward slash will also match a
+    backslash (useful when globbing Windows paths). Note that a backslash in the
+    pattern will continue to escape the following character. Defaults to
+    [false].
 
     [period]: If this flag is set, a leading period in string has to be matched exactly by
     a period in pattern. A period is considered to be leading if it is the first

--- a/lib_test/test_glob.ml
+++ b/lib_test/test_glob.ml
@@ -136,4 +136,23 @@ let _ =
   assert (re_match    (glob ~anchored ~period "/**/bat") "/.bar/bat");
   assert (re_match    (glob ~anchored ~period "/**bat") "/bar/.bat");
 
+  (* Backslash handling *)
+  let anchored = true in
+  let match_backslashes = false in
+  assert (re_mismatch   (glob ~anchored ~match_backslashes "a/b/c") "a\\b/c");
+  assert (re_match      (glob ~anchored ~match_backslashes "a\\b") "ab");
+  assert (re_match      (glob ~anchored ~match_backslashes "a/*.ml") "a/b\\c.ml");
+  assert (re_mismatch   (glob ~anchored ~match_backslashes "a/b/*.ml") "a\\b\\c.ml");
+  assert (re_mismatch   (glob ~anchored ~match_backslashes "/") "\\");
+  assert (re_mismatch   (glob ~anchored ~match_backslashes "/?") "\\a");
+  assert (re_match      (glob ~anchored ~match_backslashes "a/**.ml") "a\\c\\.b.ml");
+  let match_backslashes = true in
+  assert (re_match      (glob ~anchored ~match_backslashes "a/b/c") "a\\b/c");
+  assert (re_match      (glob ~anchored ~match_backslashes "a\\b") "ab");
+  assert (re_mismatch   (glob ~anchored ~match_backslashes "a/*.ml") "a/b\\c.ml");
+  assert (re_match      (glob ~anchored ~match_backslashes "a/b/*.ml") "a\\b\\c.ml");
+  assert (re_match      (glob ~anchored ~match_backslashes "/") "\\");
+  assert (re_match      (glob ~anchored ~match_backslashes "/?") "\\a");
+  assert (re_mismatch   (glob ~anchored ~match_backslashes "a/**.ml") "a\\c\\.b.ml");
+
   run_test_suite "test_re";


### PR DESCRIPTION
After sleeping on it a few days I realized that the API in #198 was not optimal as it removed the ability to escape characters in the glob pattern if one wanted to pattern match paths with backslashes. This PR proposes a small tweak: the new argument to `glob` activates a mode where a forward slash will also match a backslash, but a backslash on the pattern itself will continue to escape the following character.

Apologies for the back-and-forth, but I thought it is preferable to get the API right before doing a release with the new functionality!