### PR TITLE
Use correct AGPL version in opam metadata

### DIFF
--- a/re.opam
+++ b/re.opam
@@ -8,7 +8,7 @@ authors: [
   "Rudi Grinberg"
   "Gabriel Radanne"
 ]
-license: "LGPL-2.0 with OCaml linking exception"
+license: "LGPL-2.1-or-later WITH OCaml-LGPL-linking-exception"
 homepage: "https://github.com/ocaml/ocaml-re"
 bug-reports: "https://github.com/ocaml/ocaml-re/issues"
 dev-repo: "git+https://github.com/ocaml/ocaml-re.git"


### PR DESCRIPTION
Changed it so it mentions 2.1 instead of 2.0 and it now follows the SPX format for licenses.

The opam repository should be changed as well, this affects alls versions of the library AFAIK