### PR TITLE
Performance improvement

### DIFF
--- a/lib/color_map.ml
+++ b/lib/color_map.ml
@@ -24,7 +24,7 @@ let flatten cm =
     Bytes.set c i (Char.chr !v);
     Bytes.set color_repr !v (Char.chr i)
   done;
-  (c, Bytes.sub color_repr 0 (!v + 1), !v + 1)
+  (Bytes.unsafe_to_string c, Bytes.sub_string color_repr 0 (!v + 1), !v + 1)
 
 (* mark all the endpoints of the intervals of the char set with the 1 byte *)
 let split s cm =

--- a/lib/color_map.mli
+++ b/lib/color_map.mli
@@ -9,6 +9,6 @@ type t
 
 val make : unit -> t
 
-val flatten : t -> bytes * bytes * int
+val flatten : t -> string * string * int
 
 val split : Cset.t -> t -> unit

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -152,33 +152,33 @@ let validate info (s:string) ~pos st =
   let st' = find_state info.re desc' in
   st.next.(color) <- st'
 
-let rec loop info ~colors ~positions s ~pos ~last st =
+let rec loop info ~colors ~positions s ~pos ~last st0 st =
   if pos < last then
     let st' = st.next.(Char.code colors.[Char.code s.[pos]]) in
     let idx = st'.idx in
     if idx >= 0 then begin
       positions.(idx) <- pos;
-      loop info ~colors ~positions s ~pos:(pos + 1) ~last st'
+      loop info ~colors ~positions s ~pos:(pos + 1) ~last st' st'
     end else if idx = break then begin
       info.positions.(st'.real_idx) <- pos;
       st'
     end else begin (* Unknown *)
-      validate info s ~pos st;
-      loop info ~colors ~positions:info.positions s ~pos ~last st
+      validate info s ~pos st0;
+      loop info ~colors ~positions:info.positions s ~pos ~last st0 st0
     end
   else
     st
 
-let rec loop_no_mark info ~colors s ~pos ~last st =
+let rec loop_no_mark info ~colors s ~pos ~last st0 st =
   if pos < last then
     let st' = st.next.(Char.code colors.[Char.code s.[pos]]) in
     if st'.idx >= 0 then
-      loop_no_mark info ~colors s ~pos:(pos + 1) ~last st'
+      loop_no_mark info ~colors s ~pos:(pos + 1) ~last st' st'
     else if st'.idx = break then
       st'
     else begin (* Unknown *)
-      validate info s ~pos st;
-      loop_no_mark info ~colors s ~pos ~last st
+      validate info s ~pos st0;
+      loop_no_mark info ~colors s ~pos ~last st0 st0
     end
   else
     st
@@ -235,6 +235,7 @@ let rec scan_str info (s:string) initial_state ~groups =
   let pos = info.pos in
   let last = info.last in
   if (last = String.length s
+
       && info.re.lnl <> -1
       && last > pos
       && String.get s (last - 1) = '\n')
@@ -247,10 +248,10 @@ let rec scan_str info (s:string) initial_state ~groups =
       handle_last_newline info ~pos:(last - 1) st ~groups
   end else if groups then
     loop info ~colors:info.re.colors ~positions:info.positions
-      s ~pos ~last initial_state
+      s ~pos ~last initial_state initial_state
   else
     loop_no_mark
-      info ~colors:info.re.colors s ~pos ~last initial_state
+      info ~colors:info.re.colors s ~pos ~last initial_state initial_state
 
 let match_str ~groups ~partial re s ~pos ~len =
   let slen = String.length s in

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -83,9 +83,6 @@ let print_re = pp_re
 type info =
   { re : re;
     (* The automata *)
-    colors : string;
-    (* Color table ([x.colors = x.re.colors])
-       Shortcut used for performance reasons *)
     mutable positions : int array;
     (* Array of mark positions
        The mark are off by one for performance reasons *)
@@ -149,39 +146,39 @@ let delta info cat ~color st =
   desc
 
 let validate info (s:string) ~pos st =
-  let color = Char.code (info.colors.[Char.code s.[pos]]) in
+  let color = Char.code (info.re.colors.[Char.code s.[pos]]) in
   let cat = category info.re ~color in
   let desc' = delta info cat ~color st in
   let st' = find_state info.re desc' in
   st.next.(color) <- st'
 
-let rec loop info s ~pos st =
-  if pos < info.last then
-    let st' = st.next.(Char.code info.colors.[Char.code s.[pos]]) in
+let rec loop info ~colors ~positions s ~pos ~last st =
+  if pos < last then
+    let st' = st.next.(Char.code colors.[Char.code s.[pos]]) in
     let idx = st'.idx in
     if idx >= 0 then begin
-      info.positions.(idx) <- pos;
-      loop info s ~pos:(pos + 1) st'
+      positions.(idx) <- pos;
+      loop info ~colors ~positions s ~pos:(pos + 1) ~last st'
     end else if idx = break then begin
       info.positions.(st'.real_idx) <- pos;
       st'
     end else begin (* Unknown *)
       validate info s ~pos st;
-      loop info s ~pos st
+      loop info ~colors ~positions:info.positions s ~pos ~last st
     end
   else
     st
 
-let rec loop_no_mark info s ~pos ~last st =
+let rec loop_no_mark info ~colors s ~pos ~last st =
   if pos < last then
-    let st' = st.next.(Char.code info.colors.[Char.code s.[pos]]) in
+    let st' = st.next.(Char.code colors.[Char.code s.[pos]]) in
     if st'.idx >= 0 then
-      loop_no_mark info s ~pos:(pos + 1) ~last st'
+      loop_no_mark info ~colors s ~pos:(pos + 1) ~last st'
     else if st'.idx = break then
       st'
     else begin (* Unknown *)
       validate info s ~pos st;
-      loop_no_mark info s ~pos ~last st
+      loop_no_mark info ~colors s ~pos ~last st
     end
   else
     st
@@ -226,7 +223,7 @@ let rec handle_last_newline info ~pos st ~groups =
     st'
   end else begin (* Unknown *)
     let color = info.re.lnl in
-    let real_c = Char.code info.colors.[Char.code '\n'] in
+    let real_c = Char.code info.re.colors.[Char.code '\n'] in
     let cat = category info.re ~color in
     let desc' = delta info cat ~color:real_c st in
     let st' = find_state info.re desc' in
@@ -249,15 +246,17 @@ let rec scan_str info (s:string) initial_state ~groups =
     else
       handle_last_newline info ~pos:(last - 1) st ~groups
   end else if groups then
-    loop info s ~pos initial_state
+    loop info ~colors:info.re.colors ~positions:info.positions
+      s ~pos ~last initial_state
   else
-    loop_no_mark info s ~pos ~last initial_state
+    loop_no_mark
+      info ~colors:info.re.colors s ~pos ~last initial_state
 
 let match_str ~groups ~partial re s ~pos ~len =
   let slen = String.length s in
   let last = if len = -1 then slen else pos + len in
   let info =
-    { re ; colors = re.colors; pos ; last
+    { re; pos ; last
     ; positions =
         if groups then begin
           let n = Automata.index_count re.tbl + 1 in

--- a/lib/group.ml
+++ b/lib/group.ml
@@ -11,8 +11,8 @@ let offset t i =
   if 2 * i + 1 >= Array.length t.marks then raise Not_found;
   let m1 = t.marks.(2 * i) in
   if m1 = -1 then raise Not_found;
-  let p1 = t.gpos.(m1) - 1 in
-  let p2 = t.gpos.(t.marks.(2 * i + 1)) - 1 in
+  let p1 = t.gpos.(m1) in
+  let p2 = t.gpos.(t.marks.(2 * i + 1)) in
   (p1, p2)
 
 let get t i =
@@ -44,7 +44,7 @@ let all_offset t =
     if m1 <> -1 then begin
       let p1 = t.gpos.(m1) in
       let p2 = t.gpos.(t.marks.(2 * i + 1)) in
-      res.(i) <- (p1 - 1, p2 - 1)
+      res.(i) <- (p1, p2)
     end
   done;
   res
@@ -58,7 +58,7 @@ let all t =
     if m1 <> -1 then begin
       let p1 = t.gpos.(m1) in
       let p2 = t.gpos.(t.marks.(2 * i + 1)) in
-      res.(i) <- String.sub t.s (p1 - 1) (p2 - p1)
+      res.(i) <- String.sub t.s p1 (p2 - p1)
     end
   done;
   res


### PR DESCRIPTION
This makes the main loops about twice as fast by removing one memory access on the critical path and reducing the number of instructions executed per iteration. 
The downside is that we have to use `Obj.magic` and unsafe array/string accesses for that.

Indeed, we currently have two memory access on the critical path: `let st = st.next.[..]`. The idea is to remove the first memory access: `let st = st.[...]`. But then `st` no longer directly contains information on the current state of the automata but instead becomes an array of possible subsequent states, and we have to find a way to get information about the current state somehow. This is achieved by putting this information at index 0 of the array, but we need to use `Obj.magic` for that.

Once the critical path is shortened, it is no longer a bottleneck and we need to reduce the number of instructions executed by iteration as well. Hence the use of unsafe array/string accesses.