### PR TITLE
Re.Posix: fix documentation

### DIFF
--- a/lib/posix.mli
+++ b/lib/posix.mli
@@ -60,10 +60,10 @@ val re : ?opts:(opt list) -> string -> Core.t
 (** Parsing of a Posix extended regular expression *)
 
 val compile : Core.t -> Core.re
-(** Regular expression compilation *)
+(** [compile r] is defined as [Core.compile (Core.longest r)] *)
 
 val compile_pat : ?opts:(opt list) -> string -> Core.re
-(** [compile r] is defined as [Core.compile (Core.longest r)] *)
+(** [compile_pat ?opts regex] compiles the Posix extended regular expression [regexp] *)
 
 (*
 Deviation from the standard / ambiguities in the standard

--- a/lib/posix.mli
+++ b/lib/posix.mli
@@ -48,7 +48,7 @@ let match_line line =
 ]}
 *)
 
-(** XXX Character classes *)
+(* XXX Character classes *)
 
 exception Parse_error
 exception Not_supported


### PR DESCRIPTION
I haven't figured out how to get dune+odoc to render the [main module comment on ocaml.org](https://ocaml.org/p/re/1.10.3/doc/Re_posix/index.html) correctly though.

However compile and compile_pat's documentation were swapped, and it is best to document which syntax compile_pat uses, to make it clear it uses the extended syntax.

The long comment at the bottom about differences vs the standard should also be rendered in the documentation somehow...