### PR TITLE
a trivial little extension to allow querying group_count

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+Unreleased
+----------
+
+* Add `Re.group_count` to get the number of groups in a compiled regex (#218)
+
 1.10.4 (27-Apr-2022)
 --------------------
 

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -79,6 +79,8 @@ let pp_re ch re = Automata.pp ch re.initial
 
 let print_re = pp_re
 
+let group_count re = re.group_count
+
 (* Information used during matching *)
 type info =
   { re : re;

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -74,6 +74,10 @@ val compile : t -> re
 (** Compile a regular expression into an executable version that can be
     used to match strings, e.g. with {!exec}. *)
 
+val group_count : re -> int
+(** Return the number of capture groups (including the one
+    corresponding to the entire regexp). *)
+
 val exec :
   ?pos:int ->    (** Default: 0 *)
   ?len:int ->    (** Default: -1 (until end of string) *)


### PR DESCRIPTION
I'm programming a PPX rewriter based on `re`.  In this, I'd like the regexp `a(b?)c` to result in a function of type
`string -> (string * string option) option`: that is, two capture groups.  So I'd like to be able to query the compiled regexp for the # of capture groups before executing it.