### PR TITLE
Add an [exec_partial_detailed] function to re.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@ Unreleased
 ----------
 
 * Add `Re.group_count` to get the number of groups in a compiled regex (#218)
+* Add `Re.exec_partial_detailed` to allow resuming searches from partial inputs
+  (#219)
 
 1.10.4 (27-Apr-2022)
 --------------------

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -182,6 +182,18 @@ val exec_partial :
     ]}
 *)
 
+val exec_partial_detailed :
+  ?pos:int ->    (** Default: 0 *)
+  ?len:int ->    (** Default: -1 (until end of string) *)
+  re -> string -> [ `Full of Group.t | `Partial of int | `Mismatch ]
+(** More detailed version of {!exec_opt}. [`Full group] is equivalent to [Some group],
+   while [`Mismatch] and [`Partial _] are equivalent to [None], but [`Partial position]
+   indicates that the input string could be extended to create a match, and no match could
+   start in the input string before the given position.
+   This could be used to not have to search the entirety of the input if more
+   becomes available, and use the given position as the [?pos] argument.
+*)
+
 (** Marks *)
 module Mark : sig
 


### PR DESCRIPTION
This is similar to `exec_partial`, but it allows users to see the groups that matched if a match exists, and if not, then it tells you an index before which a match cannot start.

## Motivation

We had some code that was searching for a relatively small snippet within a large collection of text using regexes. This collection of text arrived in chunks, and the snippet could lie within the boundary of the chunks. We would only stop consuming chunks if we found the snippet. The most generic solution was to keep appending the chunks to a buffer, and redo the regex search from the beginning. However, that lead to $O(n^2)$ performance around larger inputs, and was resulting in significant slowdowns. Using this method, we could start the search at a later index, resulting in effectively $O(n)$ improvement.

## Alternative solutions

We could export the current state of the match, but that seemed very complicated to fit into the existing code. The solution proposed here seemed to work well in practice.

## Testing

Existing tests pass. Added additional tests for the new function.