### PR TITLE
refactor: remove bound checks

### DIFF
--- a/lib/core.ml
+++ b/lib/core.ml
@@ -161,13 +161,18 @@ let validate info (s:string) ~pos st =
 
 let rec loop info ~colors ~positions s ~pos ~last st =
   if pos < last then
-    let st' = st.next.(Char.code colors.[Char.code s.[pos]]) in
+    let st' =
+      let c =
+        let c = Char.code (String.unsafe_get s pos) in
+        Char.code (String.unsafe_get colors c)
+      in
+      Array.unsafe_get st.next c in
     let idx = st'.idx in
     if idx >= 0 then begin
-      positions.(idx) <- pos;
+      Array.unsafe_set positions idx pos;
       loop info ~colors ~positions s ~pos:(pos + 1) ~last st'
     end else if idx = break then begin
-      info.positions.(st'.real_idx) <- pos;
+      Array.unsafe_set info.positions (st'.real_idx) pos;
       st'
     end else begin (* Unknown *)
       validate info s ~pos st;
@@ -178,7 +183,7 @@ let rec loop info ~colors ~positions s ~pos ~last st =
 
 let rec loop_no_mark info ~colors s ~pos ~last st =
   if pos < last then
-    let st' = st.next.(Char.code colors.[Char.code s.[pos]]) in
+    let st' = Array.unsafe_get st.next (Char.code colors.[Char.code s.[pos]]) in
     if st'.idx >= 0 then
       loop_no_mark info ~colors s ~pos:(pos + 1) ~last st'
     else if st'.idx = break then


### PR DESCRIPTION
Bound check removal extracted from #210 for reference.

On my laptop (M2 laptop), running the bench with `$ dune exec --release ./benchmarks/benchmark.exe` yields:

```
┌──────────────────────────────────┬────────────────┬────────────┬──────────┬──────────┬────────────┐
│ Name                             │       Time/Run │    mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├──────────────────────────────────┼────────────────┼────────────┼──────────┼──────────┼────────────┤
│ 20 zeroes/exec/case 0            │        88.84ns │     54.00w │          │          │            │
│ 20 zeroes/execp/case 0           │        51.52ns │     20.00w │          │          │            │
│ 20 zeroes/exec_opt/case 0        │        88.95ns │     56.00w │          │          │            │
│ lots of a's/exec/case 0          │       299.55ns │     31.00w │          │          │      0.02% │
│ lots of a's/execp/case 0         │       200.40ns │     20.00w │          │          │      0.01% │
│ lots of a's/exec_opt/case 0      │       308.05ns │     33.00w │          │          │      0.02% │
│ media type match/exec/case 0     │        48.85ns │     31.00w │          │          │            │
│ media type match/execp/case 0    │        30.60ns │     20.00w │          │          │            │
│ media type match/exec_opt/case 0 │        49.15ns │     33.00w │          │          │            │
│ uri/exec/case 0                  │        78.77ns │     31.00w │          │          │            │
│ uri/exec/case 1                  │       149.81ns │     31.00w │          │          │            │
│ uri/exec/case 2                  │        77.01ns │     31.00w │          │          │            │
│ uri/execp/case 0                 │        46.85ns │     20.00w │          │          │            │
│ uri/execp/case 1                 │        95.31ns │     20.00w │          │          │            │
│ uri/execp/case 2                 │        46.17ns │     20.00w │          │          │            │
│ uri/exec_opt/case 0              │        80.54ns │     33.00w │          │          │            │
│ uri/exec_opt/case 1              │       151.87ns │     33.00w │          │          │            │
│ uri/exec_opt/case 2              │        80.12ns │     33.00w │          │          │            │
│ tex gitignore/execp              │    91_546.47ns │ 13_668.37w │          │          │      4.72% │
│ tex gitignore/exec_opt           │   155_082.06ns │ 26_034.80w │   -0.17w │   -0.17w │      7.99% │
│ http/manual/no group             │    70_377.99ns │     30.74w │   -0.63w │   -0.62w │      3.62% │
│ http/manual/group                │    61_598.05ns │     28.56w │          │          │      3.17% │
│ http/auto/execp no group         │    51_547.44ns │      6.06w │   -0.81w │   -0.80w │      2.65% │
│ http/auto/all_gen group          │    61_653.21ns │     64.24w │          │          │      3.18% │
│ string traversal from #210       │ 1_941_566.87ns │    -13.13w │          │          │    100.00% │
```

While on master, the results are:
```
┌──────────────────────────────────┬────────────────┬────────────┬──────────┬──────────┬────────────┐
│ Name                             │       Time/Run │    mWd/Run │ mjWd/Run │ Prom/Run │ Percentage │
├──────────────────────────────────┼────────────────┼────────────┼──────────┼──────────┼────────────┤
│ 20 zeroes/exec/case 0            │       100.34ns │     54.00w │          │          │            │
│ 20 zeroes/execp/case 0           │        69.49ns │     20.00w │          │          │            │
│ 20 zeroes/exec_opt/case 0        │        98.70ns │     56.00w │          │          │            │
│ lots of a's/exec/case 0          │       327.57ns │     31.00w │          │          │      0.01% │
│ lots of a's/execp/case 0         │       297.13ns │     20.00w │          │          │      0.01% │
│ lots of a's/exec_opt/case 0      │       339.41ns │     33.00w │          │          │      0.01% │
│ media type match/exec/case 0     │        51.87ns │     31.00w │          │          │            │
│ media type match/execp/case 0    │        33.90ns │     20.00w │          │          │            │
│ media type match/exec_opt/case 0 │        50.53ns │     33.00w │          │          │            │
│ uri/exec/case 0                  │        81.40ns │     31.00w │          │          │            │
│ uri/exec/case 1                  │       157.27ns │     31.00w │          │          │            │
│ uri/exec/case 2                  │        78.42ns │     31.00w │          │          │            │
│ uri/execp/case 0                 │        62.15ns │     20.00w │          │          │            │
│ uri/execp/case 1                 │       138.24ns │     20.00w │          │          │            │
│ uri/execp/case 2                 │        58.82ns │     20.00w │          │          │            │
│ uri/exec_opt/case 0              │        81.57ns │     33.00w │          │          │            │
│ uri/exec_opt/case 1              │       157.33ns │     33.00w │          │          │            │
│ uri/exec_opt/case 2              │        77.49ns │     33.00w │          │          │            │
│ tex gitignore/execp              │   120_796.95ns │ 13_663.61w │   -0.26w │   -0.26w │      4.34% │
│ tex gitignore/exec_opt           │   147_731.10ns │ 26_036.23w │   -0.12w │   -0.12w │      5.30% │
│ http/manual/no group             │    69_559.00ns │     30.96w │   -0.60w │   -0.60w │      2.50% │
│ http/manual/group                │    61_666.14ns │     28.56w │          │          │      2.21% │
│ http/auto/execp no group         │    69_324.53ns │      2.53w │   -1.21w │   -1.20w │      2.49% │
│ http/auto/all_gen group          │    62_509.61ns │     64.23w │          │          │      2.24% │
│ string traversal from #210       │ 2_785_498.28ns │    -20.86w │          │          │    100.00% │
└──────────────────────────────────┴────────────────┴────────────┴──────────┴──────────┴────────────┘
```