### PR TITLE
fix: simplify [Repeat]

### DIFF
--- a/lib/core.ml
+++ b/lib/core.ml
@@ -904,10 +904,11 @@ let epsilon = seq []
 
 let repn r i j =
   if i < 0 then invalid_arg "Re.repn";
-  (match j with
-   | Some j when j < i -> invalid_arg "Re.repn"
-   | _ -> ());
-  Repeat (r, i, j)
+  match j, i with
+  | Some j, _ when j < i -> invalid_arg "Re.repn"
+  | Some 0, 0 -> seq []
+  | Some 1, 1 -> r
+  | _ -> Repeat (r, i, j)
 ;;
 
 let rep r = repn r 0 None


### PR DESCRIPTION
[Repeat (_, 0, Some 0)] = empty
[Repeat (r, 1, Some 0)] = r

Signed-off-by: Rudi Grinberg <me@rgrinberg.com>