### PR TITLE
refactor: make the types in Ast private

### DIFF
--- a/lib/ast.ml
+++ b/lib/ast.ml
@@ -372,3 +372,5 @@ let rec handle_case ign_case = function
   | Ast (No_case r) -> handle_case true r
   | Pmark (i, r) -> Pmark (i, handle_case ign_case r)
 ;;
+
+let t_of_cset x = Set x

--- a/lib/ast.mli
+++ b/lib/ast.mli
@@ -1,4 +1,4 @@
-type 'a ast =
+type 'a ast = private
   | Alternative of 'a list
   | Sem of Automata.sem * 'a
   | Sem_greedy of Automata.rep_kind * 'a
@@ -6,14 +6,14 @@ type 'a ast =
   | No_case of 'a
   | Case of 'a
 
-type cset =
+type cset = private
   | Cset of Cset.t
   | Intersection of cset list
   | Complement of cset list
   | Difference of cset * cset
   | Cast of cset ast
 
-type t =
+type t = private
   | Set of cset
   | Ast of t ast
   | Sequence of t list
@@ -74,3 +74,4 @@ val alt : t list -> t
 val shortest : t -> t
 val seq : t list -> t
 val cset : Cset.t -> t
+val t_of_cset : cset -> t

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -1003,10 +1003,10 @@ module View = struct
   let view_set (cset : cset) : t =
     match cset with
     | Cset set -> Set set
-    | Intersection sets -> Intersection (ListLabels.map sets ~f:(fun x -> Ast.Set x))
-    | Complement sets -> Complement (ListLabels.map sets ~f:(fun x -> Ast.Set x))
-    | Difference (x, y) -> Difference (Set x, Set y)
-    | Cast ast -> view_ast (fun x -> Ast.Set x) ast
+    | Intersection sets -> Intersection (ListLabels.map sets ~f:Ast.t_of_cset)
+    | Complement sets -> Complement (ListLabels.map sets ~f:Ast.t_of_cset)
+    | Difference (x, y) -> Difference (Ast.t_of_cset x, Ast.t_of_cset y)
+    | Cast ast -> view_ast Ast.t_of_cset ast
   ;;
 
   let view : Ast.t -> t = function


### PR DESCRIPTION
To make it impossible to construct ast's without respecting the invariants