### PR TITLE
refactor: speed up [execp]

### DIFF
--- a/lib/compile.mli
+++ b/lib/compile.mli
@@ -23,6 +23,7 @@ val match_str
   -> len:int
   -> match_info
 
+val match_str_p : re -> string -> pos:int -> len:int -> bool
 val compile : Ast.t -> re
 val group_count : re -> int
 val group_names : re -> (string * int) list

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -60,11 +60,7 @@ let exec_opt ?pos ?len re s =
   | _ -> None
 ;;
 
-let execp ?pos ?len re s =
-  match exec_internal ~groups:false ~partial:false ?pos ?len re s with
-  | Match _substr -> true
-  | _ -> false
-;;
+let execp ?(pos = 0) ?(len = -1) re s = Compile.match_str_p ~pos ~len re s
 
 let exec_partial ?pos ?len re s =
   match exec_internal ~groups:false ~partial:true ?pos ?len re s with


### PR DESCRIPTION
there's no need to allocate the match record only to immediately throw it away in [execp]