### PR TITLE
Fix Pcre.split

### DIFF
--- a/lib/pcre.ml
+++ b/lib/pcre.ml
@@ -85,34 +85,26 @@ let substitute ~rex ~subst str =
   Buffer.contents b
 ;;
 
-let split ~rex str =
-  let finish str last accu =
-    let accu = String.sub str last (String.length str - last) :: accu in
-    List.rev accu
+let split ~rex s =
+  let rec split accu start =
+    if start = String.length s
+    then accu
+    else (
+      match
+        let g = Re.exec rex s ~pos:start in
+        if Group.stop g 0 = start then Re.exec rex s ~pos:(start + 1) else g
+      with
+      | exception Not_found -> String.sub s start (String.length s - start) :: accu
+      | g ->
+        let next = Group.stop g 0 in
+        split (String.sub s start (Group.start g 0 - start) :: accu) next)
   in
-  let rec loop accu last pos on_match =
-    if Re.execp ~pos rex str
-    then (
-      let ss = Re.exec ~pos rex str in
-      let start, fin = Re.Group.offset ss 0 in
-      if on_match && start = pos && start = fin
-      then
-        if (* Empty match following a match *)
-           pos = String.length str
-        then finish str last accu
-        else loop accu last (pos + 1) false
-      else (
-        let accu = String.sub str last (start - last) :: accu in
-        if start = fin
-        then
-          if (* Manually advance by one after an empty match *)
-             fin = String.length str
-          then finish str fin accu
-          else loop accu fin (fin + 1) false
-        else loop accu fin fin true))
-    else finish str last accu
-  in
-  loop [] 0 0 false
+  match Re.exec rex s ~pos:0 with
+  | g ->
+    if Group.start g 0 = 0
+    then List.rev (split [] (Group.stop g 0))
+    else split [ String.sub s 0 (Group.start g 0) ] (Group.stop g 0)
+  | exception Not_found -> if s = "" then [] else [ s ]
 ;;
 
 (* From PCRE *)

--- a/lib_test/expect/test_pcre_288.ml
+++ b/lib_test/expect/test_pcre_288.ml
@@ -5,11 +5,11 @@ let whitespace_re = Pcre.regexp "\\s+"
 
 let%expect_test "split1" =
   strings (Pcre.split ~rex:whitespace_re "");
-  [%expect {| [""] |}]
+  [%expect {| [] |}]
 ;;
 
 let%expect_test "split2" =
   strings (Pcre.split ~rex:whitespace_re " ");
   [%expect {|
-    [""; ""] |}]
+    [] |}]
 ;;

--- a/lib_test/expect/test_pcre_split.ml
+++ b/lib_test/expect/test_pcre_split.ml
@@ -4,20 +4,20 @@ let split ~rex s = Re.Pcre.split ~rex s |> strings
 
 let%expect_test "split" =
   split ~rex:re_whitespace "aa bb c d ";
-  [%expect {| ["aa"; "bb"; "c"; "d"; ""] |}];
+  [%expect {| ["d"; "c"; "bb"; "aa"] |}];
   split ~rex:re_whitespace " a full_word bc   ";
-  [%expect {| [""; "a"; "full_word"; "bc"; ""] |}];
+  [%expect {| ["a"; "full_word"; "bc"] |}];
   split ~rex:re_empty "abcd";
-  [%expect {| [""; "a"; "b"; "c"; "d"; ""] |}];
+  [%expect {| ["a"; "b"; "c"; "d"] |}];
   split ~rex:re_eol "a\nb";
-  [%expect {| ["a"; "\nb"; ""] |}];
+  [%expect {| ["\nb"; "a"] |}];
   split ~rex:re_bow "a b";
-  [%expect {| [""; "a "; "b"] |}];
+  [%expect {| ["a "; "b"] |}];
   split ~rex:re_eow "a b";
-  [%expect {| ["a"; " b"; ""] |}];
+  [%expect {| [" b"; "a"] |}];
   let rex = Re.Pcre.regexp "" in
   split ~rex "xx";
-  [%expect {| [""; "x"; "x"; ""] |}]
+  [%expect {| ["x"; "x"] |}]
 ;;
 
 let full_split ?max ~rex s =


### PR DESCRIPTION
An occurrence of the delimiter at the beginning or at the end of the string is ignored.

Fixes #288, fixes #411.