### PR TITLE
Fix handling in Re.{Emacs,Str}

### DIFF
--- a/lib/emacs.ml
+++ b/lib/emacs.ml
@@ -25,6 +25,12 @@ module Re = Core
 exception Parse_error
 exception Not_supported
 
+let by_code f c c' =
+  let c = Char.code c in
+  let c' = Char.code c' in
+  Char.chr (f c c')
+;;
+
 let parse s =
   let buf = Parse_buffer.create s in
   let accept = Parse_buffer.accept buf in
@@ -105,6 +111,7 @@ let parse s =
         then Re.char c :: Re.char '-' :: s
         else (
           let c' = char () in
+          let c' = by_code Int.max c c' in
           bracket (Re.rg c c' :: s))
       else bracket (Re.char c :: s))
   and char () =

--- a/lib_test/str/test_str.ml
+++ b/lib_test/str/test_str.ml
@@ -198,7 +198,10 @@ let _ =
   (* Character set *)
   expect_pass "rg" (fun () ->
     eq_match "[0-9]+" "0123456789";
-    eq_match "[0-9]+" "a");
+    eq_match "[0-9]+" "a";
+    eq_match "[9-0]+" "2";
+    eq_match "[5-5]" "5";
+    eq_match "[5-4]" "1");
   expect_pass "compl" (fun () ->
     eq_match "[^0-9a-z]+" "A:Z+";
     eq_match "[^0-9a-z]+" "0";


### PR DESCRIPTION
Backward ranges like `[5-4]` were treated incorrectly