### PR TITLE
refactor: do not nest alternations

### DIFF
--- a/lib/emacs.ml
+++ b/lib/emacs.ml
@@ -38,9 +38,9 @@ let parse s =
   let eos () = Parse_buffer.eos buf in
   let test2 = Parse_buffer.test2 buf in
   let get () = Parse_buffer.get buf in
-  let rec regexp () = regexp' (branch ())
+  let rec regexp () = regexp' [ branch () ]
   and regexp' left =
-    if accept2 '\\' '|' then regexp' (Re.alt [ left; branch () ]) else left
+    if accept2 '\\' '|' then regexp' (branch () :: left) else Re.alt (List.rev left)
   and branch () = branch' []
   and branch' left =
     if eos () || test2 '\\' '|' || test2 '\\' ')'

--- a/lib/perl.ml
+++ b/lib/perl.ml
@@ -59,8 +59,9 @@ let parse ~multiline ~dollar_endonly ~dotall ~ungreedy s =
     let gr = if ungreedy then not gr else gr in
     if gr then Re.non_greedy r else Re.greedy r
   in
-  let rec regexp () = regexp' (branch ())
-  and regexp' left = if accept '|' then regexp' (Re.alt [ left; branch () ]) else left
+  let rec regexp () = regexp' [ branch () ]
+  and regexp' left =
+    if accept '|' then regexp' (branch () :: left) else Re.alt (List.rev left)
   and branch () = branch' []
   and branch' left =
     if eos () || test '|' || test ')'

--- a/lib/posix.ml
+++ b/lib/posix.ml
@@ -40,8 +40,9 @@ let parse newline s =
   let test c = Parse_buffer.test buf c in
   let unget () = Parse_buffer.unget buf in
   let get () = Parse_buffer.get buf in
-  let rec regexp () = regexp' (branch ())
-  and regexp' left = if accept '|' then regexp' (Re.alt [ left; branch () ]) else left
+  let rec regexp () = regexp' [ branch () ]
+  and regexp' left =
+    if accept '|' then regexp' (branch () :: left) else Re.alt (List.rev left)
   and branch () = branch' []
   and branch' left =
     if eos () || test '|' || test ')'

--- a/lib_test/expect/test_alternation.ml
+++ b/lib_test/expect/test_alternation.ml
@@ -9,40 +9,20 @@ let test f string =
 
 let%expect_test "pcre" =
   test Re.Pcre.re_result "(a|b|c)";
-  [%expect
-    {|
-    (Group
-     (Set
-      (Cast (Alternative (Cast (Alternative (Cset 97) (Cset 98))) (Cset 99)))))
-    |}]
+  [%expect {| (Group (Set (Cast (Alternative (Cset 97) (Cset 98) (Cset 99))))) |}]
 ;;
 
 let%expect_test "emacs" =
   test Re.Emacs.re_result {|\(a\|b\|c\)|};
-  [%expect
-    {|
-    (Group
-     (Set
-      (Cast (Alternative (Cast (Alternative (Cset 97) (Cset 98))) (Cset 99)))))
-    |}]
+  [%expect {| (Group (Set (Cast (Alternative (Cset 97) (Cset 98) (Cset 99))))) |}]
 ;;
 
 let%expect_test "perl" =
   test Re.Perl.re_result "(a|b|c)";
-  [%expect
-    {|
-    (Group
-     (Set
-      (Cast (Alternative (Cast (Alternative (Cset 97) (Cset 98))) (Cset 99)))))
-    |}]
+  [%expect {| (Group (Set (Cast (Alternative (Cset 97) (Cset 98) (Cset 99))))) |}]
 ;;
 
 let%expect_test "posix" =
   test Re.Posix.re_result "(a|b|c)";
-  [%expect
-    {|
-    (Group
-     (Set
-      (Cast (Alternative (Cast (Alternative (Cset 97) (Cset 98))) (Cset 99)))))
-    |}]
+  [%expect {| (Group (Set (Cast (Alternative (Cset 97) (Cset 98) (Cset 99))))) |}]
 ;;


### PR DESCRIPTION
When compiling [(a|b|c)], we used to parse it as:

Re.alt [ x ; Re.alt [ y ; z ] ]

Now, we just flatten the alternation:

Re.alt [ x ; y ; z ]