### PR TITLE
Escaping in POSIX regular expressions.

### DIFF
--- a/lib/posix.ml
+++ b/lib/posix.ml
@@ -91,7 +91,7 @@ let parse newline s =
     then (
       if eos () then raise Parse_error;
       match get () with
-      | ('|' | '(' | ')' | '*' | '+' | '?' | '[' | '.' | '^' | '$' | '{' | '\\') as c ->
+      | ('|' | '(' | ')' | '*' | '+' | '?' | '[' | ']' | '.' | '^' | '$' | '{' | '}' | '\\') as c ->
         Re.char c
       | _ -> raise Parse_error)
     else (


### PR DESCRIPTION
From the `Posix` module source code, I see that `{` should be escaped but not `}`. For instance, it took me some time (and required reading the source code) to figure out that `\input{...}` should be parsed with
```ocaml
Re.Posix.re {|\\input\{([^}]*)}|}
```
Is this really intended? I would have expected both to be required to be escaped. Note that `]` is not escaped either whereas `[` is.

If this is intended for some reason, this should at least be clearly documented...