### PR TITLE
Remove explicit seq dependency

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,6 @@
  (synopsis "RE is a regular expression library for OCaml")
  (depends
   (ocaml (>= 4.12.0))
-  seq
   (ppx_expect :with-test)
   (ounit2 :with-test))
  (description "

--- a/lib/dune
+++ b/lib/dune
@@ -1,5 +1,4 @@
 (library
  (name re)
  (synopsis "Pure OCaml regular expression library")
- (libraries seq)
  (public_name re))

--- a/lib_test/expect/dune
+++ b/lib_test/expect/dune
@@ -21,6 +21,5 @@
 (subdir
  private_re
  (library
-  (name re_private)
-  (libraries seq))
+  (name re_private))
  (copy_files %{project_root}/lib/*.{ml,mli}))

--- a/re.opam
+++ b/re.opam
@@ -24,7 +24,6 @@ bug-reports: "https://github.com/ocaml/ocaml-re/issues"
 depends: [
   "dune" {>= "3.12"}
   "ocaml" {>= "4.12.0"}
-  "seq"
   "ppx_expect" {with-test}
   "ounit2" {with-test}
   "odoc" {with-doc}


### PR DESCRIPTION
seq has been included in the OCaml stdlib since 4.07, and re's lower bound is already >=4.12.0