### PR TITLE
Generate simpler code for comparisons

### DIFF
--- a/lib/import.ml
+++ b/lib/import.ml
@@ -11,8 +11,8 @@ end
 
 let ( = ) = Int.equal
 let ( == ) = [ `Use_phys_equal ]
-let ( < ) x y = Int.compare x y = -1
-let ( > ) x y = Int.compare x y = 1
+let ( < ) (x : int) (y : int) = x < y
+let ( > ) (x : int) (y : int) = x > y
 let min = Int.min
 let max = Int.max
 let compare = Int.compare


### PR DESCRIPTION
The ocaml compiler (without flambda) does not optimize `Int.compare x y = 1` into a plain comparison.