### PR TITLE
Always return results from Pcre.split in the right order

### DIFF
--- a/lib/pcre.ml
+++ b/lib/pcre.ml
@@ -108,9 +108,10 @@ let split ~rex s =
   in
   match Re.exec rex s ~pos:0 with
   | g ->
-    if Group.start g 0 = 0
-    then List.rev (split [] (Group.stop g 0))
-    else split [ String.sub s 0 (Group.start g 0) ] (Group.stop g 0)
+    List.rev
+      (if Group.start g 0 = 0
+       then split [] (Group.stop g 0)
+       else split [ String.sub s 0 (Group.start g 0) ] (Group.stop g 0))
   | exception Not_found -> if s = "" then [] else [ s ]
 ;;
 

--- a/lib_test/expect/test_pcre_split.ml
+++ b/lib_test/expect/test_pcre_split.ml
@@ -4,17 +4,17 @@ let split ~rex s = Re.Pcre.split ~rex s |> strings
 
 let%expect_test "split" =
   split ~rex:re_whitespace "aa bb c d ";
-  [%expect {| ["d"; "c"; "bb"; "aa"] |}];
+  [%expect {| ["aa"; "bb"; "c"; "d"] |}];
   split ~rex:re_whitespace " a full_word bc   ";
   [%expect {| ["a"; "full_word"; "bc"] |}];
   split ~rex:re_empty "abcd";
   [%expect {| ["a"; "b"; "c"; "d"] |}];
   split ~rex:re_eol "a\nb";
-  [%expect {| ["\nb"; "a"] |}];
+  [%expect {| ["a"; "\nb"] |}];
   split ~rex:re_bow "a b";
   [%expect {| ["a "; "b"] |}];
   split ~rex:re_eow "a b";
-  [%expect {| [" b"; "a"] |}];
+  [%expect {| ["a"; " b"] |}];
   let rex = Re.Pcre.regexp "" in
   split ~rex "xx";
   [%expect {| ["x"; "x"] |}]


### PR DESCRIPTION
Fixes #576