### PR TITLE
Backport re to OCaml 4.08

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -21,7 +21,7 @@
  (name re)
  (synopsis "RE is a regular expression library for OCaml")
  (depends
-  (ocaml (>= 4.12.0))
+  (ocaml (>= 4.08.0))
   (ppx_expect :with-test)
   (ounit2 :with-test)
   (js_of_ocaml :with-test))

--- a/lib/emacs.ml
+++ b/lib/emacs.ml
@@ -21,6 +21,7 @@
 *)
 
 module Re = Core
+open Import
 
 exception Parse_error
 exception Not_supported

--- a/lib/fake/atomic.ml
+++ b/lib/fake/atomic.ml
@@ -1,0 +1,10 @@
+type 'a t = 'a ref
+
+let make x = ref x
+let get x = !x
+let set atomic v = atomic := v
+
+let fetch_and_add atomic n =
+  let v = !atomic in
+  atomic := v + n;
+  v

--- a/lib/import.ml
+++ b/lib/import.ml
@@ -13,12 +13,13 @@ let ( = ) = Int.equal
 let ( == ) = [ `Use_phys_equal ]
 let ( < ) (x : int) (y : int) = x < y
 let ( > ) (x : int) (y : int) = x > y
-let min = Int.min
-let max = Int.max
+let min (x : int) (y : int) = if x <= y then x else y
+let max (x : int) (y : int) = if x >= y then x else y
 let compare = Int.compare
 
 module Int = struct
   let[@warning "-32"] hash (x : int) = Hashtbl.hash x
+  let[@warning "-32"] max (x : int) (y : int) = if x >= y then x else y
 
   include Stdlib.Int
 end

--- a/lib/import.ml
+++ b/lib/import.ml
@@ -1,4 +1,19 @@
-module List = Stdlib.ListLabels
+module List = struct
+  let[@warning "-32"] rec equal ~eq l1 l2 = match l1, l2 with
+    | [], [] -> true
+    | [], _::_ | _::_, [] -> false
+    | x::xs, y::ys -> if eq x y then equal ~eq xs ys else false
+
+  let[@warning "-32"] rec compare ~cmp l1 l2 = match l1, l2 with
+    | [], [] -> 0
+    | [], _::_ -> -1
+    | _::_, [] -> 1
+    | x::xs, y::ys ->
+        let r = cmp x y in
+        if r = 0 then compare ~cmp xs ys else r
+
+  include Stdlib.ListLabels
+end
 
 module Poly = struct
   let equal = ( = )

--- a/re.opam
+++ b/re.opam
@@ -23,7 +23,7 @@ homepage: "https://github.com/ocaml/ocaml-re"
 bug-reports: "https://github.com/ocaml/ocaml-re/issues"
 depends: [
   "dune" {>= "3.15"}
-  "ocaml" {>= "4.12.0"}
+  "ocaml" {>= "4.08.0"}
   "ppx_expect" {with-test}
   "ounit2" {with-test}
   "js_of_ocaml" {with-test}


### PR DESCRIPTION
Disclaimer: this is totally fine if this PR isn't merged.

I'm trying to upgrade to re 1.14.0 in opam itself and i was faced by the new lower-bound restriction on OCaml 4.13.
I needed to make a patch for us to be able to use it and i'm sharing it here in case anyone else faces the same issue.

I've split the commits in two as given the opam file expected OCaml >= 4.12 to work, i'm guessing dropping 4.12 wasn't intended.
The second commit backports to OCaml 4.08 with an implementation of atomics similar to the one added in OCaml 4.12: https://github.com/ocaml/ocaml/commit/04d9c425f38e892232078b7f56a1d323dcf8ba00

Feel free to take or drop any one of these commits