### PR TITLE
Tweak benchmarks

### DIFF
--- a/benchmarks/benchmark.ml
+++ b/benchmarks/benchmark.ml
@@ -38,12 +38,11 @@ let benchmarks =
 ;;
 
 let test ~name re f =
-  [ Bench.Test.create ~name (fun () -> f re)
-  ; (let re () =
-       let re = lazy (re ()) in
-       Lazy.force re
-     in
-     Bench.Test.create ~name:(sprintf "%s (compiled)" name) (fun () -> f re))
+  [ Bench.Test.create ~name:(sprintf "%s (comp)" name) (fun () -> re ())
+    (* No way in core_bench to test just the exec, because the compiled re is a cache,
+       which means all we measure is looping through the automaton states, not the
+       creation of such states. *)
+  ; Bench.Test.create ~name:(sprintf "%s (comp+exec)" name) (fun () -> f re)
   ]
 ;;
 

--- a/benchmarks/benchmark.ml
+++ b/benchmarks/benchmark.ml
@@ -39,10 +39,15 @@ let benchmarks =
 
 let test ~name re f =
   [ Bench.Test.create ~name:(sprintf "%s (comp)" name) (fun () -> re ())
-    (* No way in core_bench to test just the exec, because the compiled re is a cache,
-       which means all we measure is looping through the automaton states, not the
-       creation of such states. *)
   ; Bench.Test.create ~name:(sprintf "%s (comp+exec)" name) (fun () -> f re)
+  ; Bench.Test.create_with_initialization ~name:(sprintf "%s (exec)" name) (fun `init ->
+      (* No way in core_bench to bench just the exec, so the closest thing we can do is
+         bench exec + copy of all the mutable state in a regex (which should be cheap). *)
+      let re =
+        let re = re () in
+        fun () -> Re.copy_re re
+      in
+      fun () -> f re)
   ]
 ;;
 

--- a/benchmarks/compare.ml
+++ b/benchmarks/compare.ml
@@ -127,7 +127,7 @@ let merge lhs rhs =
     | `Both (lhs, rhs) -> Some (merge_one lhs rhs))
 ;;
 
-let run ~prev ~next =
+let run ~prev ~next ~sort =
   let report =
     let prev = Stdio.In_channel.read_all prev |> parse_all in
     let next = Stdio.In_channel.read_all next |> parse_all in
@@ -180,7 +180,9 @@ let run ~prev ~next =
                     ; make_delta promoted_words_per_run
                     ; make_delta minor_words_per_run
                     ] ))
-      |> List.sort ~compare:(fun (x, _) (y, _) -> Float.compare x y)
+      |> (if sort
+          then List.sort ~compare:(fun (x, _) (y, _) -> Float.compare x y)
+          else Fn.id)
       |> List.map ~f:snd
     in
     headers :: values
@@ -196,8 +198,9 @@ let command =
   Command.basic
     ~summary:"compare two runs"
     (let+ prev = flag "prev" (required string) ~doc:"sexp file"
-     and+ next = flag "next" (required string) ~doc:"sexp file" in
-     fun () -> run ~prev ~next)
+     and+ next = flag "next" (required string) ~doc:"sexp file"
+     and+ sort = flag "sort" no_arg ~doc:"sort lines in order of relative change" in
+     fun () -> run ~prev ~next ~sort)
 ;;
 
 let () = Command_unix.run command

--- a/benchmarks/compare.ml
+++ b/benchmarks/compare.ml
@@ -190,13 +190,14 @@ let run ~prev ~next =
 ;;
 
 let command =
+  let ( let+ ) x f = Command.Let_syntax.Let_syntax.map x ~f in
+  let ( and+ ) = Command.Let_syntax.Let_syntax.both in
   let open Command.Param in
-  let open Command.Param.Applicative_infix in
   Command.basic
     ~summary:"compare two runs"
-    (let prev = flag "prev" (required string) ~doc:"sexp file" in
-     let next = flag "next" (required string) ~doc:"sexp file" in
-     Command.Param.return (fun prev next () -> run ~prev ~next) <*> prev <*> next)
+    (let+ prev = flag "prev" (required string) ~doc:"sexp file"
+     and+ next = flag "next" (required string) ~doc:"sexp file" in
+     fun () -> run ~prev ~next)
 ;;
 
 let () = Command_unix.run command

--- a/benchmarks/compare.ml
+++ b/benchmarks/compare.ml
@@ -17,28 +17,43 @@ module Value = struct
     | _ -> Float (Float.of_string s)
   ;;
 
-  let rec percent_delta x y =
-    match x, y with
-    | Int x, Int y ->
-      let delta = y - x in
-      let open Float in
-      Float (100. * Float.of_int delta / Float.of_int x)
-    | Float x, Float y -> Float Float.(100. * (y - x) / x)
-    | Float x, Int y -> percent_delta (Float x) (Float (Float.of_int y))
-    | Int x, Float y -> percent_delta (Float (Float.of_int x)) (Float y)
+  let float_of_value = function
+    | Int i -> Float.of_int i
+    | Float f -> f
   ;;
 
-  let to_csv t =
-    match t with
-    | Float f -> Float.to_string_hum f
-    | Int x -> Int.to_string_hum x
+  let int_of_value = function
+    | Int i -> i
+    | Float f -> Float.iround_exn f
   ;;
 
-  let compare x y =
-    match x, y with
-    | Float x, Float y -> Float.compare x y
-    | Int x, Int y -> Int.compare x y
-    | _, _ -> assert false
+  let rel_delta x y =
+    let x = float_of_value x in
+    let y = float_of_value y in
+    if Float.( = ) x 0. && Float.( = ) y 0. then 0. else (y -. x) /. x
+  ;;
+
+  let string_of_rel_delta x y =
+    let x = float_of_value x in
+    let y = float_of_value y in
+    if Float.( > ) y (x *. 2.)
+    then Printf.sprintf "x%.1f" (y /. x)
+    else if Float.( < ) y (x /. 5.)
+    then Printf.sprintf "/%.1f" (x /. y)
+    else if Float.( = ) x 0. && Float.( = ) y 0.
+    then "."
+    else (
+      let d = (y -. x) /. x in
+      if Float.is_nan d
+      then Float.to_string d
+      else (
+        let d = Float.round (100. *. d) /. 100. in
+        if Float.( = ) d 0. then "." else Printf.sprintf "%+.0f%%" (d *. 100.)))
+  ;;
+
+  let string_of_abs_delta x y =
+    let i = Float.iround_exn (float_of_value y -. float_of_value x) in
+    if i = 0 then "." else (if i > 0 then "+" else "") ^ Int.to_string_hum i
   ;;
 end
 
@@ -121,14 +136,18 @@ let run ~prev ~next =
   let records =
     let headers =
       [ "name"
-      ; "time_per_run_nanos"
-      ; "delta (%)"
-      ; "major_words_per_run"
-      ; "delta (%)"
-      ; "promoted_words_per_run"
-      ; "delta (%)"
-      ; "minor_words_per_run"
-      ; "delta (%)"
+      ; "ns/run"
+      ; "delta"
+      ; "."
+      ; "majorW/run"
+      ; "delta"
+      ; "."
+      ; "promotedW/run"
+      ; "delta"
+      ; "."
+      ; "minorW/run"
+      ; "delta"
+      ; "."
       ]
     in
     let values =
@@ -145,11 +164,13 @@ let run ~prev ~next =
                  Value.t Both.t bench)
              ->
              let time_delta =
-               Value.percent_delta time_per_run_nanos.lhs time_per_run_nanos.rhs
+               Value.rel_delta time_per_run_nanos.lhs time_per_run_nanos.rhs
              in
              let make_delta { Both.lhs; rhs } =
-               let delta = Value.percent_delta lhs rhs in
-               [ Value.to_csv lhs; Value.to_csv delta ]
+               [ Int.to_string_hum (Value.int_of_value lhs)
+               ; Value.string_of_rel_delta lhs rhs
+               ; Value.string_of_abs_delta lhs rhs
+               ]
              in
              ( time_delta
              , name
@@ -159,7 +180,7 @@ let run ~prev ~next =
                     ; make_delta promoted_words_per_run
                     ; make_delta minor_words_per_run
                     ] ))
-      |> List.sort ~compare:(fun (x, _) (y, _) -> Value.compare x y)
+      |> List.sort ~compare:(fun (x, _) (y, _) -> Float.compare x y)
       |> List.map ~f:snd
     in
     headers :: values

--- a/benchmarks/compare.ml
+++ b/benchmarks/compare.ml
@@ -132,8 +132,7 @@ let run ~prev ~next =
       ]
     in
     let values =
-      Map.to_alist report
-      |> List.map ~f:snd
+      Map.data report
       |> List.map
            ~f:
              (fun

--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -656,6 +656,17 @@ let mk_re ~initial ~colors ~color_repr ~ncolor ~lnl ~group_names ~group_count =
   }
 ;;
 
+let copy_re re =
+  mk_re
+    ~initial:re.initial
+    ~colors:re.colors
+    ~color_repr:re.color_repr
+    ~ncolor:re.ncolor
+    ~lnl:re.lnl
+    ~group_names:re.group_names
+    ~group_count:re.group_count
+;;
+
 (**** Compilation ****)
 
 module A = Automata

--- a/lib/compile.mli
+++ b/lib/compile.mli
@@ -57,3 +57,4 @@ val compile : Ast.t -> re
 val group_count : re -> int
 val group_names : re -> (string * int) list
 val pp_re : re Fmt.t
+val copy_re : re -> re

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -165,6 +165,7 @@ include struct
   let compile = compile
   let pp_re = pp_re
   let print_re = pp_re
+  let copy_re = copy_re
   let group_names = group_names
   let group_count = group_count
 end

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -729,6 +729,12 @@ val pp_re : Format.formatter -> re -> unit
 (** Alias for {!pp_re}. Deprecated *)
 val print_re : Format.formatter -> re -> unit
 
+(**/**)
+
+val copy_re : re -> re
+
+(**/**)
+
 (** {2 Experimental functions} *)
 
 (** [witness r] generates a string [s] such that [execp (compile r) s] is true.


### PR DESCRIPTION
This is best reviewed commit by commit, see commit descriptions for each.

I changed this while looking at making color_map generate fewer colors (which can be as dramatic as 20->2 colors in regex that uses Re.word), but while the functionality is easy to write, it slows down regex compilation time, so I'm still wondering if it's improvable or worth it.