### PR TITLE
improve test/doc of exec_partial/exec_partial_detailed

### DIFF
--- a/lib/core.mli
+++ b/lib/core.mli
@@ -102,42 +102,13 @@ val group_count : re -> int
 (** Return named capture groups with their index. *)
 val group_names : re -> (string * int) list
 
-(** [exec re str] searches [str] for a match of the compiled expression [re],
-    and returns the matched groups if any.
+(** [exec_opt re str] searches [str] for a match of the compiled expression
+    [re], and returns the matched groups if any.
 
-    More specifically, when a match exists, [exec] returns a match that
+    More specifically, when a match exists, [exec_opt] returns a match that
     starts at the earliest position possible. If multiple such matches are
     possible, the one specified by the match semantics described below is
     returned.
-
-    {5 Examples:}
-    {[
-      # let regex = Re.compile Re.(seq [str "//"; rep print ]);;
-      val regex : re = <abstr>
-
-      # Re.exec regex "// a C comment";;
-      - : Re.Group.t = <abstr>
-
-      # Re.exec regex "# a C comment?";;
-      Exception: Not_found
-
-      # Re.exec ~pos:1 regex "// a C comment";;
-      Exception: Not_found
-    ]}
-
-    @param pos optional beginning of the string (default 0)
-    @param len
-      length of the substring of [str] that can be matched (default [-1],
-      meaning to the end of the string)
-    @raise Not_found if the regular expression can't be found in [str] *)
-val exec
-  :  ?pos:int (** Default: 0 *)
-  -> ?len:int (** Default: -1 (until end of string) *)
-  -> re
-  -> string
-  -> Group.t
-
-(** Similar to {!exec}, but returns an option instead of using an exception.
 
     {5 Examples:}
     {[
@@ -152,13 +123,28 @@ val exec
 
       # Re.exec_opt ~pos:1 regex "// a C comment";;
       - : Re.Group.t option = None
-    ]} *)
+    ]}
+
+    @param pos optional beginning of the string (default 0)
+    @param len
+      length of the substring of [str] that can be matched (default [-1],
+      meaning to the end of the string) *)
 val exec_opt
   :  ?pos:int (** Default: 0 *)
   -> ?len:int (** Default: -1 (until end of string) *)
   -> re
   -> string
   -> Group.t option
+
+(** Similar to {!exec_opt}, but raises Not_found instead of returning an option.
+
+    @raise Not_found if the regular expression can't be found in [str] *)
+val exec
+  :  ?pos:int (** Default: 0 *)
+  -> ?len:int (** Default: -1 (until end of string) *)
+  -> re
+  -> string
+  -> Group.t
 
 (** Similar to {!exec}, but returns [true] if the expression matches,
     and [false] if it doesn't. This function is more efficient than

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -168,9 +168,21 @@ val execp
   -> string
   -> bool
 
-(** More detailed version of {!execp}. [`Full] is equivalent to [true],
-    while [`Mismatch] and [`Partial] are equivalent to [false], but [`Partial]
-    indicates the input string could be extended to create a match.
+(** [exec_partial re str] searches [str] for a prefix of a match of [re].
+
+    - [`Full] means that [str] contains a match no matter how [str] is extended
+      (i.e. [fun more -> execp re (str ^ more)] always returns [true] and the match
+      is in [str]).
+
+    - [`Mismatch] means that no extension of [str] could match [re] (i.e.
+      [fun more -> execp re (str ^ more)] always returns [false]).
+
+    - [`Partial] is the remaining case: we need more characters to decide between
+      [`Full] and [`Mismatch]. Note that this function is not always as eager as
+      possible, meaning it can return [`Partial] when it would be technically possible
+      to return [`Full] or [`Mismatch] without consulting extra characters. One such
+      case is that re always requires one character of lookahead, so
+      [exec_partial (str "foo") "foo"] returns [`Partial].
 
     {5 Examples:}
     {[
@@ -196,12 +208,15 @@ val exec_partial
   -> string
   -> [ `Full | `Partial | `Mismatch ]
 
-(** More detailed version of {!exec_opt}. [`Full group] is equivalent to [Some group],
-    while [`Mismatch] and [`Partial _] are equivalent to [None], but [`Partial position]
-    indicates that the input string could be extended to create a match, and no match could
-    start in the input string before the given position.
-    This could be used to not have to search the entirety of the input if more
-    becomes available, and use the given position as the [?pos] argument. *)
+(** Same as {!exec_partial}, but with extra information that behave as follows:
+
+    - [`Full group] means that any extension of [str] contains the given match of
+      [re] (i.e. [fun more -> exec_opt re (str ^ more)] always returns [Some group]).
+
+    - [`Partial position]: the input string can probably be extended to create a
+      match, and no match could start in the input string before the given position.
+      This could be used to not have to search the entirety of the input if more
+      becomes available, and use the given position as the [?pos] argument. *)
 val exec_partial_detailed
   :  ?pos:int (** Default: 0 *)
   -> ?len:int (** Default: -1 (until end of string) *)

--- a/lib_test/expect/test_partial.ml
+++ b/lib_test/expect/test_partial.ml
@@ -29,6 +29,8 @@ let%expect_test "partial matches" =
   t (str "") "hello";
   [%expect {| `Full |}];
   t (whole_string (str "hello")) "";
+  [%expect {| `Partial |}];
+  t (alt [ str "ab"; str "a" ]) "a";
   [%expect {| `Partial |}]
 ;;
 
@@ -50,7 +52,7 @@ let%expect_test "partial detailed" =
   [%expect {| `Partial 6 |}];
   t (str "hello") "hello";
   [%expect {| `Full [|0,5,"hello"|] |}];
-  t (whole_string (str "hello")) "hello";
+  t (whole_string (str "hello")) "hello" (* incorrect *);
   [%expect {| `Full [|0,5,"hello"|] |}];
   t (whole_string (str "hello")) "goodbye";
   [%expect {| `Mismatch |}];
@@ -65,5 +67,10 @@ let%expect_test "partial detailed" =
   t ~pos:1 (seq [ not_boundary; str "b" ]) "ab";
   [%expect {| `Full [|1,2,"b"|] |}];
   t (seq [ group (str "a"); rep any; group (str "b") ]) ".acb.";
-  [%expect {| `Full [|1,4,"acb";1,2,"a";3,4,"b"|] |}]
+  [%expect {| `Full [|1,4,"acb";1,2,"a";3,4,"b"|] |}];
+  t (alt [ str "ab"; str "a" ]) "a";
+  [%expect {| `Full [|0,1,"a"|] |}]
+  (* incorrect, as if we extended the input with "b",
+     we'd get a different match *);
+  ()
 ;;


### PR DESCRIPTION
This is meant to be reviewed commit by commit.

A bit of work driven by #600. I think all of the test, code and documentation of `exec_partial` and `exec_partial_detailed` have issues. This is improving the test and doc, but not the code.

I'd need to think more about how to fix the code (the root problem is that re can take decisions one character too late, and these functions apparently try to work around that, but these workarounds are not correct).