### PR TITLE
fix Pcre.split (fixes #590)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+Unreleased
+----------
+
+* Fix [Re.Pcre.split] dropping or not dropping leading and trailing
+  delimiters consistently with [Pcre.split] (#602, fixes #590).
+
 1.14.0 (16-Sep-2025)
 --------------------
 

--- a/lib/pcre.ml
+++ b/lib/pcre.ml
@@ -92,6 +92,11 @@ let substitute ~rex ~subst str =
   Buffer.contents b
 ;;
 
+let rec drop_while l ~f =
+  match l with
+  | hd :: tl when f hd -> drop_while tl ~f
+  | _ -> l
+
 let split ~rex s =
   let rec split accu start =
     if start = String.length s
@@ -106,13 +111,10 @@ let split ~rex s =
         let next = Group.stop g 0 in
         split (String.sub s start (Group.start g 0 - start) :: accu) next)
   in
-  match Re.exec rex s ~pos:0 with
-  | g ->
-    List.rev
-      (if Group.start g 0 = 0
-       then split [] (Group.stop g 0)
-       else split [ String.sub s 0 (Group.start g 0) ] (Group.stop g 0))
-  | exception Not_found -> if s = "" then [] else [ s ]
+  split [] 0
+  |> drop_while ~f:(function "" -> true | _ -> false)
+  |> List.rev 
+  
 ;;
 
 (* From PCRE *)

--- a/lib_test/expect/test_pcre_split.ml
+++ b/lib_test/expect/test_pcre_split.ml
@@ -6,7 +6,7 @@ let%expect_test "split" =
   split ~rex:re_whitespace "aa bb c d ";
   [%expect {| ["aa"; "bb"; "c"; "d"] |}];
   split ~rex:re_whitespace " a full_word bc   ";
-  [%expect {| ["a"; "full_word"; "bc"] |}];
+  [%expect {| [""; "a"; "full_word"; "bc"] |}];
   split ~rex:re_empty "abcd";
   [%expect {| ["a"; "b"; "c"; "d"] |}];
   split ~rex:re_eol "a\nb";


### PR DESCRIPTION
The current `Re.Pcre.split` seems to drop one leading delimiter, but I observe the
pcre-ocaml library behaving like this:


```ocaml
# Pcre.(split ~rex:(regexp "\\/") "///");;
- : string list = []
# Pcre.(split ~rex:(regexp "\\/") "///a");;
- : string list = [""; ""; ""; "a"]
# Pcre.(split ~rex:(regexp "\\/") "a///");;
- : string list = ["a"]
# Pcre.(split ~rex:(regexp "\\/") "a////a/");;
- : string list = ["a"; ""; ""; ""; "a"]
```

I conclude that trailing delimiters are dropped, and that internal and
leading-that-are-not-trailing delimiters are kept. So I make the code behave like that.
One test changes behavior, which is a bug fix:

```ocaml
# Pcre.(split ~rex:(regexp "[\t ]+") " a full_word bc   ");;
- : string list = [""; "a"; "full_word"; "bc"]
```