### PR TITLE
make exec_partial/exec_partial_detailed behave as documented (fixes #600)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@ Unreleased
   longest match for a subexpression) was not respected in some niche
   scenarios (#610).
 
+* Fix the documentation of [Re.exec\_partial] and
+  [Re.exec\_partial\_detailed], and their implementations to follow
+  the documentation. (#601, #604, fixes #600)
+
 1.14.0 (16-Sep-2025)
 --------------------
 

--- a/lib/automata.ml
+++ b/lib/automata.ml
@@ -465,14 +465,13 @@ end = struct
   let equal = E.equal_list
   let hash = E.hash_list
 
-  let tseq' kind x y =
+  let tseq kind x y rem =
     match x with
-    | [] -> []
-    | [ TExp (marks, { def = Eps; _ }) ] -> [ TExp (marks, y) ]
-    | _ -> [ TSeq (kind, x, y) ]
+    | [] -> rem
+    | [ TExp (marks, { def = Eps; _ }) ] -> TExp (marks, y) :: rem
+    | _ -> TSeq (kind, x, y) :: rem
   ;;
 
-  let tseq kind x y rem = tseq' kind x y @ rem
   let texp marks e rem = TExp (marks, e) :: rem
 
   let rec fold_right t ~init ~f =

--- a/lib/automata.ml
+++ b/lib/automata.ml
@@ -386,12 +386,14 @@ module Desc : sig
   val to_dyn : t -> Dyn.t
   val fold_right : t -> init:'acc -> f:(E.t -> 'acc -> 'acc) -> 'acc
   val tseq : Sem.t -> t -> Expr.t -> t -> t
+  val texp : Marks.t -> Expr.t -> t -> t
   val initial : Expr.t -> t
   val empty : t
   val set_idx : Idx.t -> t -> t
   val hash : t -> int -> int
   val equal : t -> t -> bool
   val status : t -> Status.t
+  val status_is_ambiguous : t -> ambiguity_mark:Pmark.t -> bool
   val first_match : t -> Marks.t option
   val remove_matches : t -> t
   val split_at_match : t -> t * t
@@ -471,6 +473,7 @@ end = struct
   ;;
 
   let tseq kind x y rem = tseq' kind x y @ rem
+  let texp marks e rem = TExp (marks, e) :: rem
 
   let rec fold_right t ~init ~f =
     match t with
@@ -534,6 +537,12 @@ end = struct
     | [] -> Failed
     | TMatch m :: _ -> Match (Mark_infos.make (m.marks :> (int * int) list), m.pmarks)
     | _ -> Running
+  ;;
+
+  let status_is_ambiguous t ~ambiguity_mark =
+    match t with
+    | TMatch m :: _ -> Pmark.Set.mem ambiguity_mark m.pmarks
+    | _ -> false
   ;;
 
   let set_idx =
@@ -708,15 +717,23 @@ end
 (**** Computation of the next state ****)
 
 type ctx =
-  { c : Cset.c
-  ; prev_cat : Category.t
-  ; next_cat : Category.t
-  }
+  | Delta of
+      { c : Cset.c
+      ; prev_cat : Category.t
+      ; next_cat : Category.t
+      }
+  | Advance of
+      { prev_cat : Category.t
+      ; ambiguity_mark : Pmark.t
+      }
 
-let rec delta_expr ({ c; _ } as ctx) marks (x : Expr.t) rem =
+let rec delta_expr ctx marks (x : Expr.t) rem =
   (*Format.eprintf "%d@." x.id;*)
   match x.def with
-  | Cst s -> if Cset.mem c s then Desc.add_eps rem marks else rem
+  | Cst s ->
+    (match ctx with
+     | Delta { c; _ } -> if Cset.mem c s then Desc.add_eps rem marks else rem
+     | Advance _ -> Desc.texp marks x rem)
   | Alt l -> delta_alt ctx marks l rem
   | Seq (kind, y, z) ->
     let y = delta_expr ctx marks y Desc.empty in
@@ -727,9 +744,18 @@ let rec delta_expr ({ c; _ } as ctx) marks (x : Expr.t) rem =
   | Pmark i -> Desc.add_match rem (Marks.set_pmark marks i)
   | Erase (b, e) -> Desc.add_match rem (Marks.filter marks b e)
   | Before cat ->
-    if Category.intersect ctx.next_cat cat then Desc.add_match rem marks else rem
+    (match ctx with
+     | Delta { next_cat; _ } ->
+       if Category.intersect next_cat cat then Desc.add_match rem marks else rem
+     | Advance { ambiguity_mark; _ } ->
+       Desc.add_match rem (Marks.set_pmark marks ambiguity_mark))
   | After cat ->
-    if Category.intersect ctx.prev_cat cat then Desc.add_match rem marks else rem
+    let prev_cat =
+      match ctx with
+      | Delta { prev_cat; _ } -> prev_cat
+      | Advance { prev_cat; _ } -> prev_cat
+    in
+    if Category.intersect prev_cat cat then Desc.add_match rem marks else rem
 
 and delta_rep ctx marks x rep_kind kind y rem =
   let y, marks' =
@@ -768,13 +794,60 @@ and delta_desc ctx (l : Desc.t) rem =
   Desc.fold_right l ~init:rem ~f:(fun y acc -> delta_e ctx y acc)
 ;;
 
-let delta (tbl_ref : Working_area.t) next_cat char (st : State.t) =
-  let expr =
-    let prev_cat = st.category in
-    let ctx = { c = char; next_cat; prev_cat } in
-    Desc.remove_duplicates tbl_ref.seen (delta_desc ctx st.desc Desc.empty) Expr.eps_expr
-  in
+let create_state tbl_ref next_cat expr =
   let idx = Working_area.free_index tbl_ref expr in
   let expr = Desc.set_idx idx expr in
   State.mk idx next_cat expr
+;;
+
+let delta (tbl_ref : Working_area.t) next_cat char (st : State.t) =
+  let expr =
+    let prev_cat = st.category in
+    let ctx = Delta { c = char; next_cat; prev_cat } in
+    Desc.remove_duplicates tbl_ref.seen (delta_desc ctx st.desc Desc.empty) Expr.eps_expr
+  in
+  create_state tbl_ref next_cat expr
+;;
+
+(* When deriving [Re.str "abc"] wrt "a" then "b" then "c", we end up with [T (marks,
+   Eps)], i.e. not a match, until the next character. When matching whole strings, this
+   is fine because we feed in an eos character (in final_advance) if necessary. For
+   exec_partial though, it means we'd return `Prefix too conservatively. So here we
+   advance through all epsilon transitions, so that we can detect a match or a mismatch
+   without waiting for an extra character.
+
+   The wrinkle in this story is lookaheads, i.e. Before. We can't treat them as matches,
+   otherwise [exec_partial eol ""] would incorrectly say `Full. We can't leave them
+   unchanged, otherwise [exec_partial (shortest (alt [ eos; group bos ])) ""] would
+   return [`Full (second branch)], when the eos branch can also match.
+
+   Without implementing full-blown lookaheads, a solution that's enough for exec_partial
+   can be found by noticing that:
+   - if the looahead matches, the re that follows it ends up at a certain place in the
+     resulting desc
+   - if the lookahead doesn't match, that same place would hold a lower priority re that
+     was shadowed by the lookahead match, or nothing if there is no lower priority re.
+
+   This means that we can assume the lookahead matches, and if the resulting
+   Desc.status doesn't depend on that assumption (which we track using this
+   ambiguity_mark), then it means this status is independent of the lookahead. If we
+   find the ambiguity mark, then obviously the result depends on the lookahead, so we
+   can't use it.
+
+   Do not compute more transitions from the resulting state! Even when the status
+   is not ambiguous, the desc can still contain assumptions. *)
+let advance (tbl_ref : Working_area.t) (st : State.t) =
+  let expr =
+    let ambiguity_mark = Pmark.gen () in
+    let prev_cat = st.category in
+    let ctx = Advance { prev_cat; ambiguity_mark } in
+    let desc =
+      Desc.remove_duplicates
+        tbl_ref.seen
+        (delta_desc ctx st.desc Desc.empty)
+        Expr.eps_expr
+    in
+    if Desc.status_is_ambiguous desc ~ambiguity_mark then st.desc else desc
+  in
+  create_state tbl_ref st.category expr
 ;;

--- a/lib/automata.mli
+++ b/lib/automata.mli
@@ -155,3 +155,4 @@ module Working_area : sig
 end
 
 val delta : Working_area.t -> Category.t -> Cset.c -> State.t -> State.t
+val advance : Working_area.t -> State.t -> State.t

--- a/lib/compile.ml
+++ b/lib/compile.ml
@@ -297,20 +297,29 @@ let rec loop_no_mark re ~colors s ~pos ~last st0 st =
   else st
 ;;
 
-let final re st cat =
+let[@inline always] find_or_add_final re st cat ~f =
   try List.assq cat st.final with
   | Not_found ->
     Mutex.lock re.mutex;
     let res =
       try List.assq cat st.final with
       | Not_found ->
-        let st' = delta re cat ~color:Cset.null_char st in
+        let st' = f re st cat in
         let res = Automata.State.idx st', Automata.State.status_no_mutex st' in
         st.final <- (cat, res) :: st.final;
         res
     in
     Mutex.unlock re.mutex;
     res
+;;
+
+let final re st cat =
+  find_or_add_final re st cat ~f:(fun re st cat -> delta re cat ~color:Cset.null_char st)
+;;
+
+let advance re st =
+  find_or_add_final re st Category.dummy ~f:(fun re st _cat ->
+    Automata.advance re.tbl st.desc)
 ;;
 
 let find_initial_state re cat =
@@ -410,6 +419,14 @@ let final_boundary_check re positions ~last ~slen s state_info ~groups =
   res
 ;;
 
+let final_advance re positions ~last state_info ~groups =
+  let idx, res = advance re state_info in
+  (match groups, res with
+   | true, Match _ -> Positions.set positions (Automata.Idx.to_int idx) last
+   | _ -> ());
+  res
+;;
+
 let make_match_str re positions ~len ~groups ~partial s ~pos =
   let slen = String.length s in
   let last = if len = -1 then slen else pos + len in
@@ -425,23 +442,16 @@ let make_match_str re positions ~len ~groups ~partial s ~pos =
     scan_str re positions s initial_state ~pos ~last ~groups
   in
   let state_info = State.get_info st in
-  if Idx.is_break state_info.idx || (partial && not groups)
-  then Automata.State.status re.mutex state_info.desc
-  else if partial && groups
+  if partial
   then (
     match Automata.State.status re.mutex state_info.desc with
     | (Match _ | Failed) as status -> status
-    | Running ->
-      (* This could be because it's still not fully matched, or it
-         could be that because we need to run special end of input
-         checks. *)
-      (match final_boundary_check re positions ~last ~slen s state_info ~groups with
-       | Match _ as status -> status
-       | Failed | Running ->
-         (* A failure here just means that we need more data, i.e.
-            it's a partial match. *)
-         Running))
-  else final_boundary_check re positions ~last ~slen s state_info ~groups
+    | Running -> final_advance re positions ~last state_info ~groups)
+  else (
+    ();
+    if Idx.is_break state_info.idx
+    then Automata.State.status re.mutex state_info.desc
+    else final_boundary_check re positions ~last ~slen s state_info ~groups)
 ;;
 
 module Stream = struct

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -102,42 +102,13 @@ val group_count : re -> int
 (** Return named capture groups with their index. *)
 val group_names : re -> (string * int) list
 
-(** [exec re str] searches [str] for a match of the compiled expression [re],
-    and returns the matched groups if any.
+(** [exec_opt re str] searches [str] for a match of the compiled expression
+    [re], and returns the matched groups if any.
 
-    More specifically, when a match exists, [exec] returns a match that
+    More specifically, when a match exists, [exec_opt] returns a match that
     starts at the earliest position possible. If multiple such matches are
     possible, the one specified by the match semantics described below is
     returned.
-
-    {5 Examples:}
-    {[
-      # let regex = Re.compile Re.(seq [str "//"; rep print ]);;
-      val regex : re = <abstr>
-
-      # Re.exec regex "// a C comment";;
-      - : Re.Group.t = <abstr>
-
-      # Re.exec regex "# a C comment?";;
-      Exception: Not_found
-
-      # Re.exec ~pos:1 regex "// a C comment";;
-      Exception: Not_found
-    ]}
-
-    @param pos optional beginning of the string (default 0)
-    @param len
-      length of the substring of [str] that can be matched (default [-1],
-      meaning to the end of the string)
-    @raise Not_found if the regular expression can't be found in [str] *)
-val exec
-  :  ?pos:int (** Default: 0 *)
-  -> ?len:int (** Default: -1 (until end of string) *)
-  -> re
-  -> string
-  -> Group.t
-
-(** Similar to {!exec}, but returns an option instead of using an exception.
 
     {5 Examples:}
     {[
@@ -152,13 +123,28 @@ val exec
 
       # Re.exec_opt ~pos:1 regex "// a C comment";;
       - : Re.Group.t option = None
-    ]} *)
+    ]}
+
+    @param pos optional beginning of the string (default 0)
+    @param len
+      length of the substring of [str] that can be matched (default [-1],
+      meaning to the end of the string) *)
 val exec_opt
   :  ?pos:int (** Default: 0 *)
   -> ?len:int (** Default: -1 (until end of string) *)
   -> re
   -> string
   -> Group.t option
+
+(** Similar to {!exec_opt}, but raises Not_found instead of returning an option.
+
+    @raise Not_found if the regular expression can't be found in [str] *)
+val exec
+  :  ?pos:int (** Default: 0 *)
+  -> ?len:int (** Default: -1 (until end of string) *)
+  -> re
+  -> string
+  -> Group.t
 
 (** Similar to {!exec}, but returns [true] if the expression matches,
     and [false] if it doesn't. This function is more efficient than

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -168,9 +168,21 @@ val execp
   -> string
   -> bool
 
-(** More detailed version of {!execp}. [`Full] is equivalent to [true],
-    while [`Mismatch] and [`Partial] are equivalent to [false], but [`Partial]
-    indicates the input string could be extended to create a match.
+(** [exec_partial re str] searches [str] for a prefix of a match of [re].
+
+    - [`Full] means that [str] contains a match no matter how [str] is extended
+      (i.e. [fun more -> execp re (str ^ more)] always returns [true] and the match
+      is in [str]).
+
+    - [`Mismatch] means that no extension of [str] could match [re] (i.e.
+      [fun more -> execp re (str ^ more)] always returns [false]).
+
+    - [`Partial] is the remaining case: we need more characters to decide between
+      [`Full] and [`Mismatch]. Note that this function is not always as eager as
+      possible, meaning it can return [`Partial] when it would be technically possible
+      to return [`Full] or [`Mismatch] without consulting extra characters. One such
+      case is that re always requires one character of lookahead, so
+      [exec_partial (str "foo") "foo"] returns [`Partial].
 
     {5 Examples:}
     {[
@@ -196,12 +208,15 @@ val exec_partial
   -> string
   -> [ `Full | `Partial | `Mismatch ]
 
-(** More detailed version of {!exec_opt}. [`Full group] is equivalent to [Some group],
-    while [`Mismatch] and [`Partial _] are equivalent to [None], but [`Partial position]
-    indicates that the input string could be extended to create a match, and no match could
-    start in the input string before the given position.
-    This could be used to not have to search the entirety of the input if more
-    becomes available, and use the given position as the [?pos] argument. *)
+(** Same as {!exec_partial}, but with extra information that behave as follows:
+
+    - [`Full group] means that any extension of [str] contains the given match of
+      [re] (i.e. [fun more -> exec_opt re (str ^ more)] always returns [Some group]).
+
+    - [`Partial position]: the input string can probably be extended to create a
+      match, and no match could start in the input string before the given position.
+      This could be used to not have to search the entirety of the input if more
+      becomes available, and use the given position as the [?pos] argument. *)
 val exec_partial_detailed
   :  ?pos:int (** Default: 0 *)
   -> ?len:int (** Default: -1 (until end of string) *)

--- a/lib/core.mli
+++ b/lib/core.mli
@@ -181,8 +181,9 @@ val execp
       [`Full] and [`Mismatch]. Note that this function is not always as eager as
       possible, meaning it can return [`Partial] when it would be technically possible
       to return [`Full] or [`Mismatch] without consulting extra characters. One such
-      case is that re always requires one character of lookahead, so
-      [exec_partial (str "foo") "foo"] returns [`Partial].
+      case is [exec_partial (seq [eos; str "a"]) ""] which returns [`Partial],
+      even though no string will ever match the regular expression, but it's nontrivial
+      to determine that.
 
     {5 Examples:}
     {[

--- a/lib_test/expect/test_automata.ml
+++ b/lib_test/expect/test_automata.ml
@@ -18,7 +18,7 @@ end
 
 let pp_state state = print_dyn (State.to_dyn state)
 let pp_expr fmt expr = Automata.pp fmt expr
-let cat = Category.dummy
+let cat = Category.from_char '\000'
 
 let str ids sem str =
   let rec loop (s : Char.t Seq.t) =

--- a/lib_test/expect/test_partial.ml
+++ b/lib_test/expect/test_partial.ml
@@ -17,9 +17,8 @@ let%expect_test "partial matches" =
   [%expect {| `Partial |}];
   t (str "hello") "goodbye";
   [%expect {| `Partial |}];
-  (* exec_partial 3 should be `Full *)
   t (str "hello") "hello";
-  [%expect {| `Partial |}];
+  [%expect {| `Full |}];
   t (whole_string (str "hello")) "hello";
   [%expect {| `Partial |}];
   t (whole_string (str "hello")) "goodbye";
@@ -31,7 +30,12 @@ let%expect_test "partial matches" =
   t (whole_string (str "hello")) "";
   [%expect {| `Partial |}];
   t (alt [ str "ab"; str "a" ]) "a";
-  [%expect {| `Partial |}]
+  [%expect {| `Partial |}];
+  t (seq [ str "ab"; bos ]) "ab";
+  [%expect {| `Mismatch |}];
+  t (seq [ str "ab"; eos ]) "ab";
+  [%expect {| `Partial |}];
+  ()
 ;;
 
 let t = exec_partial_detailed
@@ -52,8 +56,8 @@ let%expect_test "partial detailed" =
   [%expect {| `Partial 6 |}];
   t (str "hello") "hello";
   [%expect {| `Full [|0,5,"hello"|] |}];
-  t (whole_string (str "hello")) "hello" (* incorrect *);
-  [%expect {| `Full [|0,5,"hello"|] |}];
+  t (whole_string (str "hello")) "hello";
+  [%expect {| `Partial 0 |}];
   t (whole_string (str "hello")) "goodbye";
   [%expect {| `Mismatch |}];
   t (str "hello") "";
@@ -66,11 +70,13 @@ let%expect_test "partial detailed" =
   [%expect {| `Partial 4 |}];
   t ~pos:1 (seq [ not_boundary; str "b" ]) "ab";
   [%expect {| `Full [|1,2,"b"|] |}];
-  t (seq [ group (str "a"); rep any; group (str "b") ]) ".acb.";
+  t (seq [ group (str "a"); shortest (rep any); group (str "b") ]) ".acb.";
   [%expect {| `Full [|1,4,"acb";1,2,"a";3,4,"b"|] |}];
   t (alt [ str "ab"; str "a" ]) "a";
-  [%expect {| `Full [|0,1,"a"|] |}]
-  (* incorrect, as if we extended the input with "b",
-     we'd get a different match *);
+  [%expect {| `Partial 0 |}];
+  t (seq [ str "ab"; bos ]) "ab";
+  [%expect {| `Mismatch |}];
+  t (seq [ str "ab"; eos ]) "ab";
+  [%expect {| `Partial 0 |}];
   ()
 ;;

--- a/lib_test/expect/test_partial.ml
+++ b/lib_test/expect/test_partial.ml
@@ -29,6 +29,8 @@ let%expect_test "partial matches" =
   t (str "") "hello";
   [%expect {| `Full |}];
   t (whole_string (str "hello")) "";
+  [%expect {| `Partial |}];
+  t (alt [ str "ab"; str "a" ]) "a";
   [%expect {| `Partial |}]
 ;;
 
@@ -50,7 +52,7 @@ let%expect_test "partial detailed" =
   [%expect {| `Partial 6 |}];
   t (str "hello") "hello";
   [%expect {| `Full [|0,5,"hello"|] |}];
-  t (whole_string (str "hello")) "hello";
+  t (whole_string (str "hello")) "hello" (* incorrect *);
   [%expect {| `Full [|0,5,"hello"|] |}];
   t (whole_string (str "hello")) "goodbye";
   [%expect {| `Mismatch |}];
@@ -65,5 +67,10 @@ let%expect_test "partial detailed" =
   t ~pos:1 (seq [ not_boundary; str "b" ]) "ab";
   [%expect {| `Full [|1,2,"b"|] |}];
   t (seq [ group (str "a"); rep any; group (str "b") ]) ".acb.";
-  [%expect {| `Full [|1,4,"acb";1,2,"a";3,4,"b"|] |}]
+  [%expect {| `Full [|1,4,"acb";1,2,"a";3,4,"b"|] |}];
+  t (alt [ str "ab"; str "a" ]) "a";
+  [%expect {| `Full [|0,1,"a"|] |}]
+  (* incorrect, as if we extended the input with "b",
+     we'd get a different match *);
+  ()
 ;;


### PR DESCRIPTION
(this is built on the sibling PR, so review the last two commits only)

Without this change, these functions return `Full sometimes too eagerly, and sometimes
not eagerly enough. And exec_partial and exec_partial_detailed were not consistent
with each other.

I fuzzed the documented property about prefixes, and it finds no failure in 50M tries,
whereas a previous iteration of this change failed before 500K.

One concern with this is whether we're breaking users. There's literally not a single
user of these functions in sherlocode: https://sherlocode.com/?q=exec_partial , so I
imagine there can't be many uses in private code either. Given the lack of
documentation, I gather that any user, if they exist, must have adapted to whatever
behavior they observed, and will perhaps have to do so again.

Another concern is whether the automata.ml changes slows down regular execution.
I think the answer is:
- no, considering benchmarks look neutral (one bench at +6%, one at -6%, most
  between -2% and +2%), and the extra code seems like it should be ~free (no
  extra allocation, extra branches can be predicted, the tag of the branch
  is in a cacheline that should be in cache)
- since there's a bit of variance in the benchmarks, I tacked on a
  trivial-to-write optimization in the next commit, so the benchmarks are
  undoubtedly improved