### PR TITLE
glob: fix issue with ** being sometimes too strict, and sometimes too lax

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,13 @@ Unreleased
 * Fix [Re.Pcre.split] dropping or not dropping leading and trailing
   delimiters consistently with [Pcre.split] (#602, fixes #590).
 
+* Fix [Re.Glob] issue where `a/**b` matched `ab` (#611)
+
+* Change [Re.Glob] so `**/a` matches `a`, as that's least surprising
+  (git, bash, hg and rg all agree on this). The only change is at start of
+  glob, as `a/**/b` already matched `a/b`. Should you want to match at
+  least one directory deep, you can use `*/**/a`. (#611, fixes #171)
+
 1.14.0 (16-Sep-2025)
 --------------------
 

--- a/lib/glob.ml
+++ b/lib/glob.ml
@@ -34,7 +34,7 @@ type piece =
   | Any_but of enclosed list
   | One
   | Many
-  | ManyMany
+  | ManyMany of { component_with_terminator : bool }
 
 type t = piece list
 
@@ -66,10 +66,18 @@ let of_string ~double_asterisk s : t =
     loop []
   in
   let piece acc =
-    if double_asterisk && Parse_buffer.accept_s buf "/**"
-    then ManyMany :: (if eos () then Exactly '/' :: acc else acc)
+    if double_asterisk
+       && (match acc with
+           | [] | Exactly '/' :: _ -> true
+           | _ -> false)
+       && Parse_buffer.accept_s buf "**/"
+    then ManyMany { component_with_terminator = true } :: acc
     else if read '*'
-    then (if double_asterisk && read '*' then ManyMany else Many) :: acc
+    then
+      (if double_asterisk && read '*'
+       then ManyMany { component_with_terminator = false }
+       else Many)
+      :: acc
     else if read '?'
     then One :: acc
     else if not (read '[')
@@ -184,28 +192,30 @@ let exactly state c =
   State.append state (Re.alt (List.map Re.char chars)) ~am_at_start_of_component
 ;;
 
-let many_many state =
+let many_many state ~component_with_terminator =
   let explicit_period = state.State.period && state.State.pathname in
   let first_explicit_period = State.explicit_period state in
   let slashes = State.slashes state in
+  let slashes_re = Re.alt (List.map Re.char slashes) in
   let match_component ~explicit_period =
     Re.seq
       [ one ~explicit_slash:true ~slashes ~explicit_period
       ; Re.rep (one ~explicit_slash:true ~slashes ~explicit_period:false)
       ]
   in
+  let match_components =
+    Re.seq
+      [ Re.opt (match_component ~explicit_period:first_explicit_period)
+      ; Re.rep (Re.seq [ slashes_re; Re.opt (match_component ~explicit_period) ])
+      ]
+  in
   (* We must match components individually when [period] flag is set,
      making sure to not match ["foo/.bar"]. *)
   State.append
     state
-    (Re.seq
-       [ Re.opt (match_component ~explicit_period:first_explicit_period)
-       ; Re.rep
-           (Re.seq
-              [ Re.alt (List.map Re.char slashes)
-              ; Re.opt (match_component ~explicit_period)
-              ])
-       ])
+    (if component_with_terminator
+     then Re.opt (Re.seq [ match_components; slashes_re ])
+     else match_components)
 ;;
 
 let many (state : State.t) =
@@ -267,7 +277,9 @@ let many (state : State.t) =
       | Some (Any_of enclosed, state) -> enclosed_set state `Any_of enclosed
       | Some (Any_but enclosed, state) -> enclosed_set state `Any_but enclosed
       (* * then ** === ** *)
-      | Some (ManyMany, state) -> many_many state
+      | Some (ManyMany { component_with_terminator }, state) ->
+        assert (not component_with_terminator);
+        many_many state ~component_with_terminator
     in
     lookahead state)
 ;;
@@ -288,7 +300,7 @@ let piece state piece =
       state
       (enclosed_set `Any_but ~explicit_slash ~slashes ~explicit_period enclosed)
   | Exactly c -> exactly state c
-  | ManyMany -> many_many state
+  | ManyMany { component_with_terminator } -> many_many state ~component_with_terminator
 ;;
 
 let glob ~pathname ~match_backslashes ~period glob =
@@ -309,6 +321,7 @@ let glob
   ?(double_asterisk = true)
   s
   =
+  let double_asterisk = double_asterisk && pathname in
   let to_re s =
     let re = glob ~pathname ~match_backslashes ~period (of_string ~double_asterisk s) in
     if anchored then Re.whole_string re else re

--- a/lib/glob.mli
+++ b/lib/glob.mli
@@ -55,9 +55,9 @@ exception Parse_error
     e.g. a\{x,y\}b\{1,2\} matches axb1, axb2, ayb1, ayb2.  As specified for bash, brace
     expansion is purely textual and can be nested. Defaults to false.
 
-    [double_asterisk]: If this flag is set, double asterisks ('**') will match slash
-    characters, even if [pathname] is set. The [period] flag still applies. Default to
-    true. *)
+    [double_asterisk]: when both this flag and pathname are set, double asterisks ('**')
+    will match slash characters, and '/**/' (or '**/' at the front) will match zero or
+    more path components . The [period] flag still applies. Default to true. *)
 val glob
   :  ?anchored:bool
   -> ?pathname:bool

--- a/lib_test/expect/test_glob.ml
+++ b/lib_test/expect/test_glob.ml
@@ -8,6 +8,16 @@ let glob ?match_backslashes ?expand_braces ?anchored ?pathname ?period re s =
   Format.printf "%b@." (Re.execp re s)
 ;;
 
+let globs ?match_backslashes ?expand_braces ?anchored ?pathname ?period re_str strings =
+  let re =
+    Re.Glob.glob ?match_backslashes ?expand_braces ?anchored ?pathname ?period re_str
+    |> Re.compile
+  in
+  List.iter strings ~f:(fun s ->
+    let res = if Re.execp re s then "✓" else "x" in
+    Format.printf "glob=%s   %s %s@." re_str res s)
+;;
+
 let%expect_test "glob" =
   glob "foo*" "foobar";
   [%expect {| true |}];
@@ -131,54 +141,64 @@ let%expect_test "glob" =
 
 let%expect_test "double asterisk" =
   let glob = glob ~anchored:true in
-  glob "**" "foobar";
-  [%expect {| true |}];
-  glob "**" "foo/bar";
-  [%expect {| true |}];
-  glob "**/bar" "foo/bar";
-  [%expect {| true |}];
-  glob "**/bar" "foo/far/bar";
-  [%expect {| true |}];
-  glob "foo/**" "foo";
-  [%expect {| false |}];
-  glob "foo/**" "foo/bar";
-  [%expect {| true |}];
-  glob "foo/**" "foo/far/bar";
-  [%expect {| true |}];
-  glob "foo/**/bar" "foo/far/bar";
-  [%expect {| true |}];
-  glob "foo/**/bar" "foo/far/oof/bar";
-  [%expect {| true |}];
-  glob "foo/**bar" "foo/far/oofbar";
-  [%expect {| true |}];
-  glob "foo/**bar" "foo/bar";
-  [%expect {| true |}];
-  glob "foo/**bar" "foo/foobar";
-  [%expect {| true |}];
-  glob "/**" "//foo";
-  [%expect {| true |}];
-  glob "/**" "/";
-  [%expect {| true |}];
-  glob "/**" "/x";
-  [%expect {| true |}];
-  glob "**" "foo//bar";
-  [%expect {| true |}];
-  glob "foo/bar/**/*.ml" "foo/bar/baz/foobar.ml";
-  [%expect {| true |}];
-  glob "foo/bar/**/*.ml" "foo/bar/foobar.ml";
-  [%expect {| true |}];
-  glob "foo/**/bar/**/baz" "foo/bar/baz";
-  [%expect {| true |}];
-  glob "foo/**/bar/**/baz" "foo/bar/x/y/z/baz";
-  [%expect {| true |}];
-  glob "foo/**/bar/**/baz" "foo/x/y/z/bar/baz";
-  [%expect {| true |}];
-  glob "foo/**/bar/**/baz" "foo/bar/x/bar/x/baz";
-  [%expect {| true |}];
-  glob "foo/**/bar/**/baz" "foo/bar/../x/baz";
-  [%expect {| false |}];
-  glob "foo/**/bar/**/baz" "foo/bar/./x/baz";
-  [%expect {| false |}];
+  let globs = globs ~anchored:true in
+  globs "**" [ "foobar"; "foo/bar" ];
+  [%expect {|
+    glob=**   ✓ foobar
+    glob=**   ✓ foo/bar
+    |}];
+  globs "**/bar" [ "foo/bar"; "foo/far/bar" ];
+  [%expect {|
+    glob=**/bar   ✓ foo/bar
+    glob=**/bar   ✓ foo/far/bar
+    |}];
+  globs "foo/**" [ "foo"; "foo/bar"; "foo/far/bar" ];
+  [%expect {|
+    glob=foo/**   x foo
+    glob=foo/**   ✓ foo/bar
+    glob=foo/**   ✓ foo/far/bar
+    |}];
+  globs "foo/**/bar" [ "foo/far/bar"; "foo/far/oof/bar" ];
+  [%expect {|
+    glob=foo/**/bar   ✓ foo/far/bar
+    glob=foo/**/bar   ✓ foo/far/oof/bar
+    |}];
+  globs "foo/**bar" [ "foo/far/oofbar"; "foo/bar"; "foo/foobar" ];
+  [%expect {|
+    glob=foo/**bar   ✓ foo/far/oofbar
+    glob=foo/**bar   ✓ foo/bar
+    glob=foo/**bar   ✓ foo/foobar
+    |}];
+  globs "/**" [ "//foo"; "/"; "/x" ];
+  [%expect {|
+    glob=/**   ✓ //foo
+    glob=/**   ✓ /
+    glob=/**   ✓ /x
+    |}];
+  globs "**" [ "foo//bar" ];
+  [%expect {| glob=**   ✓ foo//bar |}];
+  globs "foo/bar/**/*.ml" [ "foo/bar/baz/foobar.ml"; "foo/bar/foobar.ml" ];
+  [%expect {|
+    glob=foo/bar/**/*.ml   ✓ foo/bar/baz/foobar.ml
+    glob=foo/bar/**/*.ml   ✓ foo/bar/foobar.ml
+    |}];
+  globs
+    "foo/**/bar/**/baz"
+    [ "foo/bar/baz"
+    ; "foo/bar/x/y/z/baz"
+    ; "foo/x/y/z/bar/baz"
+    ; "foo/bar/x/bar/x/baz"
+    ; "foo/bar/../x/baz"
+    ; "foo/bar/./x/baz"
+    ];
+  [%expect {|
+    glob=foo/**/bar/**/baz   ✓ foo/bar/baz
+    glob=foo/**/bar/**/baz   ✓ foo/bar/x/y/z/baz
+    glob=foo/**/bar/**/baz   ✓ foo/x/y/z/bar/baz
+    glob=foo/**/bar/**/baz   ✓ foo/bar/x/bar/x/baz
+    glob=foo/**/bar/**/baz   x foo/bar/../x/baz
+    glob=foo/**/bar/**/baz   x foo/bar/./x/baz
+    |}];
   ((* Interaction with [~period] *)
    let glob = glob ~period:true in
    glob "**" ".foobar";

--- a/lib_test/expect/test_glob.ml
+++ b/lib_test/expect/test_glob.ml
@@ -152,7 +152,7 @@ let%expect_test "double asterisk" =
   globs "**/bar" [ "bar"; "foo/bar"; "foo/far/bar"; "z/zbar" ];
   [%expect
     {|
-    glob=**/bar   x bar
+    glob=**/bar   ✓ bar
     glob=**/bar   ✓ foo/bar
     glob=**/bar   ✓ foo/far/bar
     glob=**/bar   x z/zbar
@@ -172,7 +172,7 @@ let%expect_test "double asterisk" =
     glob=foo/**/bar   ✓ foo/far/bar
     glob=foo/**/bar   ✓ foo/far/oof/bar
     glob=foo/**/bar   ✓ foo/bar
-    glob=foo/**/bar   ✓ foofar/bar
+    glob=foo/**/bar   x foofar/bar
     glob=foo/**/bar   x foo/farbar
     glob=foo/**/bar   x foobar
     |}];
@@ -190,7 +190,7 @@ let%expect_test "double asterisk" =
     glob=foo/**bar   ✓ foo/far/oofbar
     glob=foo/**bar   ✓ foo/bar
     glob=foo/**bar   ✓ foo/foobar
-    glob=foo/**bar   ✓ foobar
+    glob=foo/**bar   x foobar
     |}];
   globs "/**" [ "//foo"; "/"; "/x"; "x" ];
   [%expect
@@ -284,7 +284,7 @@ let%expect_test "backslash handling" =
    glob "/?" "\\a";
    [%expect {| false |}];
    glob "a/**.ml" "a\\c\\.b.ml";
-   [%expect {| true |}]);
+   [%expect {| false |}]);
   let glob = glob ~match_backslashes:true in
   glob "a/b/c" "a\\b/c";
   [%expect {| true |}];

--- a/lib_test/expect/test_glob.ml
+++ b/lib_test/expect/test_glob.ml
@@ -142,43 +142,67 @@ let%expect_test "glob" =
 let%expect_test "double asterisk" =
   let glob = glob ~anchored:true in
   let globs = globs ~anchored:true in
-  globs "**" [ "foobar"; "foo/bar" ];
-  [%expect {|
+  globs "**" [ "foobar"; "foo/bar"; "foo//bar" ];
+  [%expect
+    {|
     glob=**   ✓ foobar
     glob=**   ✓ foo/bar
+    glob=**   ✓ foo//bar
     |}];
-  globs "**/bar" [ "foo/bar"; "foo/far/bar" ];
-  [%expect {|
+  globs "**/bar" [ "bar"; "foo/bar"; "foo/far/bar"; "z/zbar" ];
+  [%expect
+    {|
+    glob=**/bar   x bar
     glob=**/bar   ✓ foo/bar
     glob=**/bar   ✓ foo/far/bar
+    glob=**/bar   x z/zbar
     |}];
   globs "foo/**" [ "foo"; "foo/bar"; "foo/far/bar" ];
-  [%expect {|
+  [%expect
+    {|
     glob=foo/**   x foo
     glob=foo/**   ✓ foo/bar
     glob=foo/**   ✓ foo/far/bar
     |}];
-  globs "foo/**/bar" [ "foo/far/bar"; "foo/far/oof/bar" ];
-  [%expect {|
+  globs
+    "foo/**/bar"
+    [ "foo/far/bar"; "foo/far/oof/bar"; "foo/bar"; "foofar/bar"; "foo/farbar"; "foobar" ];
+  [%expect
+    {|
     glob=foo/**/bar   ✓ foo/far/bar
     glob=foo/**/bar   ✓ foo/far/oof/bar
+    glob=foo/**/bar   ✓ foo/bar
+    glob=foo/**/bar   ✓ foofar/bar
+    glob=foo/**/bar   x foo/farbar
+    glob=foo/**/bar   x foobar
     |}];
-  globs "foo/**bar" [ "foo/far/oofbar"; "foo/bar"; "foo/foobar" ];
-  [%expect {|
+  globs "foo**/bar" [ "bar"; "foo/bar"; "foo/far/bar"; "foobar" ];
+  [%expect
+    {|
+    glob=foo**/bar   x bar
+    glob=foo**/bar   ✓ foo/bar
+    glob=foo**/bar   ✓ foo/far/bar
+    glob=foo**/bar   x foobar
+    |}];
+  globs "foo/**bar" [ "foo/far/oofbar"; "foo/bar"; "foo/foobar"; "foobar" ];
+  [%expect
+    {|
     glob=foo/**bar   ✓ foo/far/oofbar
     glob=foo/**bar   ✓ foo/bar
     glob=foo/**bar   ✓ foo/foobar
+    glob=foo/**bar   ✓ foobar
     |}];
-  globs "/**" [ "//foo"; "/"; "/x" ];
-  [%expect {|
+  globs "/**" [ "//foo"; "/"; "/x"; "x" ];
+  [%expect
+    {|
     glob=/**   ✓ //foo
     glob=/**   ✓ /
     glob=/**   ✓ /x
+    glob=/**   x x
     |}];
-  globs "**" [ "foo//bar" ];
-  [%expect {| glob=**   ✓ foo//bar |}];
   globs "foo/bar/**/*.ml" [ "foo/bar/baz/foobar.ml"; "foo/bar/foobar.ml" ];
-  [%expect {|
+  [%expect
+    {|
     glob=foo/bar/**/*.ml   ✓ foo/bar/baz/foobar.ml
     glob=foo/bar/**/*.ml   ✓ foo/bar/foobar.ml
     |}];
@@ -191,7 +215,8 @@ let%expect_test "double asterisk" =
     ; "foo/bar/../x/baz"
     ; "foo/bar/./x/baz"
     ];
-  [%expect {|
+  [%expect
+    {|
     glob=foo/**/bar/**/baz   ✓ foo/bar/baz
     glob=foo/**/bar/**/baz   ✓ foo/bar/x/y/z/baz
     glob=foo/**/bar/**/baz   ✓ foo/x/y/z/bar/baz


### PR DESCRIPTION
(to be read commit by commit)

There are two problems here.
First, `a/**b` matches `ab`, which is just incorrect.
Second, `**/a` didn't match `a` (even though `b/**/a` does match `b/a`). I think this is unexpected (see commits messages), so I'm changing it, and this fixes #171.