### PR TITLE
Improve doc and tests for Re.Mark

### DIFF
--- a/lib/core.mli
+++ b/lib/core.mli
@@ -38,8 +38,7 @@ type t = Ast.t
     contention while trying to share work.
 
     [Re] is not domain-safe as a whole. In particular {!Re.Str} isn't domain-safe, just
-    like {!Str} isn't.
-  *)
+    like {!Str} isn't. *)
 type re = Compile.re
 
 (** Manipulate matching groups. *)
@@ -225,8 +224,19 @@ val exec_partial_detailed
   -> string
   -> [ `Full of Group.t | `Partial of int | `Mismatch ]
 
-(** Marks *)
 module Mark : sig
+  (** A mark allows checking whether a subexpression was used in a match.
+
+      This is much like a group, with the upside that the stability of mark ids can be
+      more convenient than group indices that change depending where other groups are,
+      but with the downside that marks don't provide positions.
+
+      Performance-wise, marks are cheaper, and it's possible to iterate over only
+      _matched_ marks in a match (vs one can only iterate over all groups in the match).
+      This can be useful if you have a large alternation and want to know which branch
+      is taken (e.g. one branch per gitignore line, and you want to check which line
+      ignores each pathname in a long list). *)
+
   (** Mark id *)
   type t = Pmark.t
 

--- a/lib/pmark.ml
+++ b/lib/pmark.ml
@@ -11,14 +11,9 @@ end
 include Pmark
 
 module Set = struct
-  module Set = Set.Make (Pmark)
+  include Set.Make (Pmark)
 
-  let[@warning "-32"] to_list x =
-    let open Set in
-    to_seq x |> List.of_seq
-  ;;
-
-  include Set
+  let to_list = elements
 end
 
 let to_dyn = Dyn.int

--- a/lib_test/expect/test_mark.ml
+++ b/lib_test/expect/test_mark.ml
@@ -1,53 +1,56 @@
 open Import
 open Re
+module Mark_map = Map.Make (Mark)
 
-let test_mark ?pos ?len r s il1 il2 =
-  let subs = exec ?pos ?len (compile r) s in
-  Format.printf
-    "%b@."
-    (List.for_all ~f:(Mark.test subs) il1
-     && List.for_all ~f:(fun x -> not (Mark.test subs x)) il2)
+let names = ref Mark_map.empty
+
+let mark name r =
+  let mark, r = mark r in
+  names := Mark_map.add mark name !names;
+  r
+;;
+
+let test_mark ?pos ?len r s =
+  exec ?pos ?len (compile r) s
+  |> Mark.all
+  |> Mark.Set.elements
+  |> List.map ~f:(fun mark ->
+    match Mark_map.find_opt mark !names with
+    | None -> "?"
+    | Some name -> name)
+  |> List.sort ~cmp:String.compare
+  |> String.concat " "
+  |> print_endline
 ;;
 
 let%expect_test "mark" =
-  let i, r = mark digit in
-  test_mark r "0" [ i ] [];
-  [%expect {| true |}]
+  test_mark (mark "i" digit) "0";
+  [%expect {| i |}]
 ;;
 
 let%expect_test "mark seq" =
-  let i, r = mark digit in
-  let r = seq [ r; r ] in
-  test_mark r "02" [ i ] [];
-  [%expect {| true |}]
+  let r = mark "i" digit in
+  test_mark (seq [ r; r ]) "02";
+  [%expect {| i |}]
 ;;
 
 let%expect_test "mark rep" =
-  let i, r = mark digit in
-  let r = rep r in
-  test_mark r "02" [ i ] [];
-  [%expect {| true |}]
+  test_mark (rep (mark "i" digit)) "02";
+  [%expect {| i |}]
 ;;
 
 let%expect_test "mark alt" =
-  let ia, ra = mark (char 'a') in
-  let ib, rb = mark (char 'b') in
-  let r = alt [ ra; rb ] in
-  test_mark r "a" [ ia ] [ ib ];
-  test_mark r "b" [ ib ] [ ia ];
-  [%expect {|
-    true
-    true |}];
-  let r = rep r in
-  test_mark r "ab" [ ia; ib ] [];
-  [%expect {| true |}]
+  let r = alt [ mark "ia" (char 'a'); mark "ib" (char 'b') ] in
+  test_mark r "a";
+  [%expect {| ia |}];
+  test_mark r "b";
+  [%expect {| ib |}];
+  test_mark (rep r) "ab";
+  [%expect {| ia ib |}]
 ;;
 
 let%expect_test "mark prefers lhs" =
   let two_chars = seq [ any; any ] in
-  let lhs, x = mark two_chars in
-  let rhs, x' = mark two_chars in
-  let r = alt [ x; x' ] in
-  test_mark r "aa" [ lhs ] [ rhs ];
-  [%expect {| true |}]
+  test_mark (alt [ mark "lhs" two_chars; mark "rhs" two_chars ]) "aa";
+  [%expect {| lhs |}]
 ;;


### PR DESCRIPTION
It seems worth contrasting marks vs groups in the doc, as every regex implementation provides groups, but I've never seen something like marks. I thought the difference was mostly about performance (matching being O(number of groups + number of matched marks), but matching is independent of both if we exclude compilation/derivation), but now I think it's mostly that mark id can be more convenient.

I update the tests and the code while trying to understand things, but no user visible change.

(as a side note, I noticed that we could provide a function `val exec_marks : re -> string -> Mark.Set.t` and it would actually be zero alloc, if all relevant transitions are already forced. Pretty cool. But no one seems to need that, so I'm not including that change)