### PR TITLE
Minor tweaks to benchmark code

### DIFF
--- a/benchmarks/benchmark.ml
+++ b/benchmarks/benchmark.ml
@@ -210,7 +210,7 @@ let () =
       let filtered =
         List.filter benchmarks ~f:(fun bench ->
           let name = Bench.Test.name bench in
-          List.mem only name ~equal:String.equal)
+          List.exists only ~f:(fun pattern -> String.is_prefix ~prefix:pattern name))
       in
       (match filtered with
        | _ :: _ -> filtered

--- a/benchmarks/http.ml
+++ b/benchmarks/http.ml
@@ -32,9 +32,9 @@ end
 let requests = Stdio.In_channel.read_all "benchmarks/http-requests.txt"
 
 let rec read_all pos re reqs =
-  if pos < String.length reqs
-  then (
-    let g = Re.exec ~pos re reqs in
+  match Re.exec ~pos re reqs with
+  | exception Not_found -> ()
+  | g ->
     let _, pos = Re.Group.offset g 0 in
-    read_all (pos + 1) re reqs)
+    read_all (pos + 1) re reqs
 ;;


### PR DESCRIPTION
In ways that were useful for https://github.com/v-gb/ocaml-re/tree/utf-lookarounds/

The Http.read_all change is because I use that function as a utility function for new benchmarks in that branch.