### PR TITLE
document Re.Str as not domain/thread-safe, and provide an alternative

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,9 @@ Unreleased
   [Re.exec\_partial\_detailed], and their implementations to follow
   the documentation. (#601, #604, fixes #600)
 
+* Provide [Re.Str.re] to combine the [Str] syntax with the
+  thread/domain-safety of [Re.exec*] (#615, fixes #194)
+
 1.14.0 (16-Sep-2025)
 --------------------
 

--- a/lib/emacs.ml
+++ b/lib/emacs.ml
@@ -125,18 +125,13 @@ let parse ~emacs_only s =
   res
 ;;
 
-let re ?(case = true) s =
-  let r = parse s ~emacs_only:true in
+let re ?(str_compatible = false) ?(case = true) s =
+  let r = parse s ~emacs_only:(not str_compatible) in
   if case then r else Re.no_case r
 ;;
 
-let re_no_emacs ~case s =
-  let r = parse s ~emacs_only:false in
-  if case then r else Re.no_case r
-;;
-
-let re_result ?case s =
-  match re ?case s with
+let re_result ?str_compatible ?case s =
+  match re ?str_compatible ?case s with
   | s -> Ok s
   | exception Not_supported -> Error `Not_supported
   | exception Parse_error -> Error `Parse_error

--- a/lib/emacs.mli
+++ b/lib/emacs.mli
@@ -27,15 +27,19 @@ exception Parse_error
 (** Errors that can be raised during the parsing of the regular expression *)
 exception Not_supported
 
-(** Parsing of an Emacs-style regular expression *)
-val re : ?case:bool -> string -> Core.t
+(** Parsing of an Emacs-style regular expression.
 
-val re_result : ?case:bool -> string -> (Core.t, [ `Not_supported | `Parse_error ]) result
+    [str_compatible] indicate whether to parse the regex compatibly with [Re.Str]. *)
+val re : ?str_compatible:bool -> ?case:bool -> string -> Core.t
+
+val re_result
+  :  ?str_compatible:bool
+  -> ?case:bool
+  -> string
+  -> (Core.t, [ `Not_supported | `Parse_error ]) result
 
 (** Regular expression compilation *)
 val compile : Core.t -> Core.re
 
 (** Same as [Core.compile] *)
 val compile_pat : ?case:bool -> string -> Core.re
-
-val re_no_emacs : case:bool -> string -> Core.t

--- a/lib/str.ml
+++ b/lib/str.ml
@@ -29,8 +29,11 @@ type regexp =
   ; srch : Compile.re Lazy.t
   }
 
+let re s = Emacs.re ~str_compatible:true s
+let re_result s = Emacs.re_result ~str_compatible:true s
+
 let compile_regexp s c =
-  let re = Emacs.re_no_emacs ~case:(not c) s in
+  let re = Emacs.re ~str_compatible:true ~case:(not c) s in
   { mtch = lazy (Compile.compile (Ast.seq [ Ast.start; re ]))
   ; srch = lazy (Compile.compile re)
   }

--- a/lib/str.mli
+++ b/lib/str.mli
@@ -13,7 +13,11 @@
 
 (* $Id: re_str.mli,v 1.1 2002/01/16 14:16:04 vouillon Exp $ *)
 
-(** Module [Str]: regular expressions and high-level string processing *)
+(** Module [Str]: regular expressions and high-level string processing
+
+    This module as a whole is neither thread-safe nor domain-safe, but [re] and
+    [re_result] can be used to combine the [Str] syntax with the matching functions in
+    [Re], which are domain-safe and thread-safe. *)
 
 (** {2 Regular expressions} *)
 
@@ -58,6 +62,12 @@ val regexp_string : string -> regexp
 (** [Str.regexp_string_case_fold] is similar to [Str.regexp_string], but the regexp
     matches in a case-insensitive way. *)
 val regexp_string_case_fold : string -> regexp
+
+(** [re s] parses [s] just like [regexp] does, but gives you back a regexp to be used
+    with [Re.exec*]. *)
+val re : string -> Core.t
+
+val re_result : string -> (Core.t, [ `Not_supported | `Parse_error ]) result
 
 (** {2 String matching and searching} *)
 


### PR DESCRIPTION
Specifically, provide Re.Str.{re,re_result}, to combine Str syntax with Re matching functions. The other syntaxes (Re.Glob, Re.Pcre, Re.Perl, Re.Posix) all do this, so it seems reasonable to me to do the same here.

This fixes #194.